### PR TITLE
Ext to OutProp

### DIFF
--- a/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidActivity.kt
+++ b/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidActivity.kt
@@ -50,17 +50,16 @@ interface IBundleStateSaver<GState> {
  * [AppCompatActivity] and [Fragment].
  * @receiver An [IPropInjector] instance.
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param application An [Application] instance.
  * @param saver An [IBundleStateSaver] instance.
  * @param inject Function that performs injections on [LifecycleOwner] instances passing through.
  * @return An [Application.ActivityLifecycleCallbacks] instance.
  */
-fun <GState, GExt> IPropInjector<GState, GExt>.injectActivity(
+fun <GState> IPropInjector<GState>.injectActivity(
   application: Application,
   saver: IBundleStateSaver<GState>,
-  inject: IPropInjector<GState, GExt>.(LifecycleOwner) -> Unit
-): Application.ActivityLifecycleCallbacks where GState : Any, GExt : Any {
+  inject: IPropInjector<GState>.(LifecycleOwner) -> Unit
+): Application.ActivityLifecycleCallbacks where GState : Any {
   val callback = object : Application.ActivityLifecycleCallbacks {
     override fun onActivityPaused(activity: Activity?) {}
     override fun onActivityResumed(activity: Activity?) {}
@@ -96,15 +95,14 @@ fun <GState, GExt> IPropInjector<GState, GExt>.injectActivity(
  * Similar to [injectActivity], but provides default persistence for when [GState] is
  * [Serializable].
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param application An [Application] instance.
  * @param inject Function that performs injections on [LifecycleOwner] instances passing through.
  * @return An [Application.ActivityLifecycleCallbacks] instance.
  */
-inline fun <reified GState, GExt> IPropInjector<GState, GExt>.injectActivitySerializable(
+inline fun <reified GState> IPropInjector<GState>.injectActivitySerializable(
   application: Application,
-  noinline inject: IPropInjector<GState, GExt>.(LifecycleOwner) -> Unit
-): Application.ActivityLifecycleCallbacks where GState : Any, GState : Serializable, GExt : Any {
+  noinline inject: IPropInjector<GState>.(LifecycleOwner) -> Unit
+): Application.ActivityLifecycleCallbacks where GState : Any, GState : Serializable {
   val key = "REDUX_STATE_${Date().time}"
 
   return this.injectActivity(application, object : IBundleStateSaver<GState> {
@@ -120,15 +118,14 @@ inline fun <reified GState, GExt> IPropInjector<GState, GExt>.injectActivitySeri
  * Similar to [injectActivity], but provides default persistence for when [GState] is
  * [Parcelable].
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param application An [Application] instance.
  * @param inject Function that performs injections on [LifecycleOwner] instances passing through.
  * @return An [Application.ActivityLifecycleCallbacks] instance.
  */
-inline fun <reified GState, GExt> IPropInjector<GState, GExt>.injectActivityParcelable(
+inline fun <reified GState> IPropInjector<GState>.injectActivityParcelable(
   application: Application,
-  noinline inject: IPropInjector<GState, GExt>.(LifecycleOwner) -> Unit
-): Application.ActivityLifecycleCallbacks where GState : Any, GState : Parcelable, GExt : Any {
+  noinline inject: IPropInjector<GState>.(LifecycleOwner) -> Unit
+): Application.ActivityLifecycleCallbacks where GState : Any, GState : Parcelable {
   val key = "REDUX_STATE_${Date().time}"
 
   return this.injectActivity(application, object : IBundleStateSaver<GState> {

--- a/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidFragment.kt
+++ b/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidFragment.kt
@@ -32,14 +32,13 @@ class AppCompatActivityWrapper(private val activity: AppCompatActivity) : IAppCo
  * session automatically disposes of itself when [ReduxLifecycleObserver.onDestroy] is called.
  * @receiver An [IPropInjector] instance.
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param activity An [IAppCompatActivity] instance.
  * @param inject Function that performs injections on [LifecycleOwner] instances passing through.
  */
-internal fun <GState, GExt> IPropInjector<GState, GExt>.injectFragment(
+internal fun <GState> IPropInjector<GState>.injectFragment(
   activity: IAppCompatActivity,
-  inject: IPropInjector<GState, GExt>.(LifecycleOwner) -> Unit
-) where GState : Any, GExt : Any {
+  inject: IPropInjector<GState>.(LifecycleOwner) -> Unit
+) where GState : Any {
   val callback = object : FragmentManager.FragmentLifecycleCallbacks() {
     override fun onFragmentStarted(fm: FragmentManager, f: Fragment) {
       inject(this@injectFragment, f)
@@ -65,13 +64,12 @@ internal fun <GState, GExt> IPropInjector<GState, GExt>.injectFragment(
 /**
  * Call [injectFragment] with an [AppCompatActivity].
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param activity An [AppCompatActivity] instance.
  * @param inject Function that performs injections on [LifecycleOwner] instances passing through.
  */
-internal fun <GState, GExt> IPropInjector<GState, GExt>.injectFragment(
+internal fun <GState> IPropInjector<GState>.injectFragment(
   activity: AppCompatActivity,
-  inject: IPropInjector<GState, GExt>.(LifecycleOwner) -> Unit
-) where GState : Any, GExt : Any {
+  inject: IPropInjector<GState>.(LifecycleOwner) -> Unit
+) where GState : Any {
   return this.injectFragment(AppCompatActivityWrapper(activity), inject)
 }

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
@@ -11,7 +11,6 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.swiften.redux.core.CompositeReduxSubscription
 import org.swiften.redux.core.ReduxSubscription
-import org.swiften.redux.ui.IActionDependency
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
 import org.swiften.redux.ui.IPropMapper
@@ -35,28 +34,25 @@ interface IDiffItemCallback<T> {
  * Custom Redux-compatible [ListAdapter] implementation. This [ListAdapter] can receive [ReduxProps]
  * in order to call [ListAdapter.submitList].
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param LState The local state type that [GState] must extend from.
- * @param LExt See [IActionDependency.external]. [GExt] must extend from this parameter.
+ * @param OutProps Property as defined by [this]'s parent.
  * @param VH The [RecyclerView.ViewHolder] instance.
  * @param VHState The [VH] state type. See [ReduxProps.state].
  * @param VHAction The [VH] action type. See [ReduxProps.action].
  * @param adapter The base [RecyclerView.Adapter] instance.
  * @param diffCallback A [DiffUtil.ItemCallback] instance.
  */
-abstract class ReduxListAdapter<GState, GExt, LState, LExt, VH, VHState, VHAction>(
+abstract class ReduxListAdapter<GState, LState, OutProps, VH, VHState, VHAction>(
   private val adapter: RecyclerView.Adapter<VH>,
   diffCallback: DiffUtil.ItemCallback<VHState>
 ) : ListAdapter<VHState, VH>(diffCallback),
-  IPropContainer<LState, LExt, List<VHState>, VHAction> where
+  IPropContainer<LState, OutProps, List<VHState>, VHAction> where
   GState : LState,
-  GExt : LExt,
   LState : Any,
-  LExt : Any,
   VH : RecyclerView.ViewHolder,
   VHState : Any,
   VHAction : Any {
-  internal lateinit var staticProps: StaticProps<LState, LExt>
+  internal lateinit var staticProps: StaticProps<LState, OutProps>
 
   /**
    * Since we will be manually injecting props into [VH] instances, we will need to collect their
@@ -73,7 +69,7 @@ abstract class ReduxListAdapter<GState, GExt, LState, LExt, VH, VHState, VHActio
     this.submitList(next.state ?: arrayListOf())
   }
 
-  override fun beforePropInjectionStarts(sp: StaticProps<LState, LExt>) {
+  override fun beforePropInjectionStarts(sp: StaticProps<LState, OutProps>) {
     this.staticProps = sp
   }
 
@@ -136,38 +132,36 @@ abstract class ReduxListAdapter<GState, GExt, LState, LExt, VH, VHState, VHActio
  *
  * Since we do not call [IPropInjector.inject] directly into [VH], we cannot use
  * [IPropMapper.mapAction] on [VH] itself. As a result, we must pass down
- * [ReduxProps.action] from [ReduxListAdapter.reduxProps] into each [VH] instance. The [VHAction] should
- * contain actions that take at least one [Int] parameter, (e.g. (Int) -> Unit), so that we can use
- * [RecyclerView.ViewHolder.getLayoutPosition] to call them.
+ * [ReduxProps.action] from [ReduxListAdapter.reduxProps] into each [VH] instance. The [VHAction]
+ * should contain actions that take at least one [Int] parameter, (e.g. (Int) -> Unit), so that we
+ * can use [RecyclerView.ViewHolder.getLayoutPosition] to call them.
  *
  * Note that this does not support lifecycle handling, so we will need to manually set null via
  * [RecyclerView.setAdapter] to invoke [RecyclerView.Adapter.onDetachedFromRecyclerView].
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
- * @param LState The local state type that [GState] must extend from.
- * @param LExt See [IActionDependency.external]. [GExt] must extend from this parameter.
+ * @param OutProps Property as defined by [adapter]'s parent.
  * @param VH The [RecyclerView.ViewHolder] instance.
  * @param VHState The [VH] state type. See [ReduxProps.state].
  * @param VHAction The [VH] action type. See [ReduxProps.action].
  * @param adapter The base [RecyclerView.Adapter] instance.
+ * @param outProps An [OutProps] instance.
  * @param adapterMapper An [IPropMapper] instance for [ReduxListAdapter].
  * @param diffCallback A [DiffUtil.ItemCallback] instance.
  */
 @Suppress("UNCHECKED_CAST")
-fun <GState, GExt, LState, LExt, VH, VHState, VHAction> IPropInjector<GState, GExt>.injectDiffedAdapter(
+fun <GState, LState, OutProps, VH, VHState, VHAction> IPropInjector<GState>.injectDiffedAdapter(
   adapter: RecyclerView.Adapter<VH>,
-  adapterMapper: IPropMapper<LState, LExt, Unit, List<VHState>, VHAction>,
+  outProps: OutProps,
+  adapterMapper: IPropMapper<LState, OutProps, List<VHState>, VHAction>,
   diffCallback: DiffUtil.ItemCallback<VHState>
-): ReduxListAdapter<GState, GExt, LState, LExt, VH, VHState, VHAction> where
+): ReduxListAdapter<GState, LState, OutProps, VH, VHState, VHAction> where
   GState : LState,
-  GExt : LExt,
   LState : Any,
-  LExt : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, LExt, VHState, VHAction>,
+  VH : IPropContainer<LState, OutProps, VHState, VHAction>,
   VHState : Any,
   VHAction : Any {
-  val listAdapter = object : ReduxListAdapter<GState, GExt, LState, LExt, VH, VHState, VHAction>(adapter, diffCallback) {
+  val listAdapter = object : ReduxListAdapter<GState, LState, OutProps, VH, VHState, VHAction>(adapter, diffCallback) {
     override fun onBindViewHolder(holder: VH, position: Int) {
       adapter.onBindViewHolder(holder, position)
       val subscribeId = "$holder${Date().time}"
@@ -183,6 +177,6 @@ fun <GState, GExt, LState, LExt, VH, VHState, VHAction> IPropInjector<GState, GE
     }
   }
 
-  this.inject(listAdapter, Unit, adapterMapper)
+  this.inject(listAdapter, outProps, adapterMapper)
   return listAdapter
 }

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/LifecycleAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/LifecycleAdapter.kt
@@ -41,12 +41,12 @@ fun <GState, LState, OutProps, VH, VHState, VHAction> IPropInjector<GState>.inje
   adapter: RecyclerView.Adapter<VH>,
   outProps: OutProps,
   adapterMapper: IStateMapper<LState, Unit, Int>,
-  vhMapper: IPropMapper<LState, Pair<OutProps, Int>, VHState, VHAction>
+  vhMapper: IPropMapper<LState, PositionProps<OutProps>, VHState, VHAction>
 ): RecyclerView.Adapter<VH> where
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, Pair<OutProps, Int>, VHState, VHAction>,
+  VH : IPropContainer<LState, PositionProps<OutProps>, VHState, VHAction>,
   VHState : Any,
   VHAction : Any {
   val wrappedAdapter = this.injectRecyclerAdapter(adapter, outProps, adapterMapper, vhMapper)

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/LifecycleAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/LifecycleAdapter.kt
@@ -11,7 +11,6 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.swiften.redux.android.ui.lifecycle.ILifecycleCallback
 import org.swiften.redux.android.ui.lifecycle.ReduxLifecycleObserver
-import org.swiften.redux.ui.IActionDependency
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
 import org.swiften.redux.ui.IPropMapper
@@ -24,34 +23,33 @@ import org.swiften.redux.ui.unsubscribeSafely
  * Perform [injectRecyclerAdapter], but also handle lifecycle with [lifecycleOwner].
  * @receiver An [IPropInjector] instance.
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param LState The local state type that [GState] must extend from.
- * @param LExt See [IActionDependency.external]. [GExt] must extend from this parameter.
+ * @param OutProps Property as defined by [lifecycleOwner]'s parent.
  * @param VH The [RecyclerView.ViewHolder] instance.
  * @param VHState The [VH] state type. See [ReduxProps.state].
  * @param VHAction The [VH] action type. See [ReduxProps.action].
  * @param lifecycleOwner A [LifecycleOwner] instance.
  * @param adapter The base [RecyclerView.Adapter] instance.
+ * @param outProps An [OutProps] instance.
  * @param adapterMapper An [IStateMapper] instance that calculates item count for
  * [RecyclerView.Adapter.getItemCount].
  * @param vhMapper An [IPropMapper] instance for [VH].
  * @return A [RecyclerView.Adapter] instance.
  */
-fun <GState, GExt, LState, LExt, VH, VHState, VHAction> IPropInjector<GState, GExt>.injectRecyclerAdapter(
+fun <GState, LState, OutProps, VH, VHState, VHAction> IPropInjector<GState>.injectRecyclerAdapter(
   lifecycleOwner: LifecycleOwner,
   adapter: RecyclerView.Adapter<VH>,
+  outProps: OutProps,
   adapterMapper: IStateMapper<LState, Unit, Int>,
-  vhMapper: IPropMapper<LState, LExt, Int, VHState, VHAction>
+  vhMapper: IPropMapper<LState, Pair<OutProps, Int>, VHState, VHAction>
 ): RecyclerView.Adapter<VH> where
   GState : LState,
-  GExt : LExt,
   LState : Any,
-  LExt : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, LExt, VHState, VHAction>,
+  VH : IPropContainer<LState, Pair<OutProps, Int>, VHState, VHAction>,
   VHState : Any,
   VHAction : Any {
-  val wrappedAdapter = this.injectRecyclerAdapter(adapter, adapterMapper, vhMapper)
+  val wrappedAdapter = this.injectRecyclerAdapter(adapter, outProps, adapterMapper, vhMapper)
 
   ReduxLifecycleObserver(lifecycleOwner, object : ILifecycleCallback {
     override fun onSafeForStartingLifecycleAwareTasks() {}
@@ -67,31 +65,31 @@ fun <GState, GExt, LState, LExt, VH, VHState, VHAction> IPropInjector<GState, GE
  * @param GState The global state type.
  * @param GExt See [IPropInjector.external].
  * @param LState The local state type that [GState] must extend from.
- * @param LExt See [IActionDependency.external]. [GExt] must extend from this parameter.
+ * @param OutProps Property as defined by [lifecycleOwner]'s parent.
  * @param VH The [RecyclerView.ViewHolder] instance.
  * @param VHState The [VH] state type. See [ReduxProps.state].
  * @param VHAction The [VH] action type. See [ReduxProps.action].
  * @param lifecycleOwner A [LifecycleOwner] instance.
  * @param adapter The base [RecyclerView.Adapter] instance.
+ * @param outProps An [OutProps] instance.
  * @param adapterMapper An [IPropMapper] instance for [ReduxListAdapter].
  * @param diffCallback A [DiffUtil.ItemCallback] instance.
  * @return A [ListAdapter] instance.
  */
-fun <GState, GExt, LState, LExt, VH, VHState, VHAction> IPropInjector<GState, GExt>.injectDiffedAdapter(
+fun <GState, LState, OutProps, VH, VHState, VHAction> IPropInjector<GState>.injectDiffedAdapter(
   lifecycleOwner: LifecycleOwner,
   adapter: RecyclerView.Adapter<VH>,
-  adapterMapper: IPropMapper<LState, LExt, Unit, List<VHState>, VHAction>,
+  outProps: OutProps,
+  adapterMapper: IPropMapper<LState, OutProps, List<VHState>, VHAction>,
   diffCallback: DiffUtil.ItemCallback<VHState>
 ): ListAdapter<VHState, VH> where
   GState : LState,
-  GExt : LExt,
   LState : Any,
-  LExt : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, LExt, VHState, VHAction>,
+  VH : IPropContainer<LState, OutProps, VHState, VHAction>,
   VHState : Any,
   VHAction : Any {
-  val wrappedAdapter = this.injectDiffedAdapter(adapter, adapterMapper, diffCallback)
+  val wrappedAdapter = this.injectDiffedAdapter(adapter, outProps, adapterMapper, diffCallback)
 
   ReduxLifecycleObserver(lifecycleOwner, object : ILifecycleCallback {
     override fun onSafeForStartingLifecycleAwareTasks() {}
@@ -109,33 +107,32 @@ fun <GState, GExt, LState, LExt, VH, VHState, VHAction> IPropInjector<GState, GE
  * Instead of [DiffUtil.ItemCallback], use [IDiffItemCallback] to avoid abstract class.
  * @receiver An [IPropInjector] instance.
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param LState The local state type that [GState] must extend from.
- * @param LExt See [IActionDependency.external]. [GExt] must extend from this parameter.
+ * @param OutProps Property as defined by [lifecycleOwner]'s parent.
  * @param VH The [RecyclerView.ViewHolder] instance.
  * @param VHState The [VH] state type. See [ReduxProps.state].
  * @param VHAction The [VH] action type. See [ReduxProps.action].
  * @param lifecycleOwner A [LifecycleOwner] instance.
  * @param adapter The base [RecyclerView.Adapter] instance.
+ * @param outProps An [OutProps] instance.
  * @param adapterMapper An [IPropMapper] instance for [ReduxListAdapter].
  * @param diffCallback A [IDiffItemCallback] instance.
  * @return A [ListAdapter] instance.
  */
-fun <GState, GExt, LState, LExt, VH, VHState, VHAction> IPropInjector<GState, GExt>.injectDiffedAdapter(
+fun <GState, LState, OutProps, VH, VHState, VHAction> IPropInjector<GState>.injectDiffedAdapter(
   lifecycleOwner: LifecycleOwner,
   adapter: RecyclerView.Adapter<VH>,
-  adapterMapper: IPropMapper<LState, LExt, Unit, List<VHState>, VHAction>,
+  outProps: OutProps,
+  adapterMapper: IPropMapper<LState, OutProps, List<VHState>, VHAction>,
   diffCallback: IDiffItemCallback<VHState>
 ): ListAdapter<VHState, VH> where
   GState : LState,
-  GExt : LExt,
   LState : Any,
-  LExt : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, LExt, VHState, VHAction>,
+  VH : IPropContainer<LState, OutProps, VHState, VHAction>,
   VHState : Any,
   VHAction : Any {
-  return this.injectDiffedAdapter(lifecycleOwner, adapter, adapterMapper,
+  return this.injectDiffedAdapter(lifecycleOwner, adapter, outProps, adapterMapper,
     object : DiffUtil.ItemCallback<VHState>() {
       override fun areItemsTheSame(oldItem: VHState, newItem: VHState): Boolean {
         return diffCallback.areItemsTheSame(oldItem, newItem)

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
@@ -31,6 +31,14 @@ abstract class ReduxRecyclerViewAdapter<VH : RecyclerView.ViewHolder> : Recycler
 }
 
 /**
+ * Use this as container for outer props for [DelegateRecyclerAdapter] view holder.
+ * @param OutProps The main external props.
+ * @param external An [OutProps] instance.
+ * @param position The view holder's position.
+ */
+class PositionProps<OutProps>(val external: OutProps, val position: Int)
+
+/**
  * [RecyclerView.Adapter] that delegates method calls to another [RecyclerView.Adapter].
  * @param GState The global state type.
  * @param LState The local state type that [GState] must extend from.
@@ -46,7 +54,7 @@ abstract class DelegateRecyclerAdapter<GState, LState, OutProps, VH, VHState, VH
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, Pair<OutProps, Int>, VHState, VHAction>,
+  VH : IPropContainer<LState, PositionProps<OutProps>, VHState, VHAction>,
   VHState : Any,
   VHAction : Any {
   protected val composite = CompositeReduxSubscription("${this.javaClass}${Date().time}")
@@ -133,12 +141,12 @@ fun <GState, LState, OutProps, VH, VHState, VHAction> IPropInjector<GState>.inje
   adapter: RecyclerView.Adapter<VH>,
   outProps: OutProps,
   adapterMapper: IStateMapper<LState, Unit, Int>,
-  vhMapper: IPropMapper<LState, Pair<OutProps, Int>, VHState, VHAction>
+  vhMapper: IPropMapper<LState, PositionProps<OutProps>, VHState, VHAction>
 ): DelegateRecyclerAdapter<GState, LState, OutProps, VH, VHState, VHAction> where
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, Pair<OutProps, Int>, VHState, VHAction>,
+  VH : IPropContainer<LState, PositionProps<OutProps>, VHState, VHAction>,
   VHState : Any,
   VHAction : Any {
   return object : DelegateRecyclerAdapter<GState, LState, OutProps, VH, VHState, VHAction>(adapter) {
@@ -147,7 +155,8 @@ fun <GState, LState, OutProps, VH, VHState, VHAction> IPropInjector<GState>.inje
     }
 
     override fun onBindViewHolder(holder: VH, position: Int) {
-      val subscription = this@injectRecyclerAdapter.inject(holder, outProps to position, vhMapper)
+      val vhOutProps = PositionProps(outProps, position)
+      val subscription = this@injectRecyclerAdapter.inject(holder, vhOutProps, vhMapper)
       this.composite.add(subscription)
     }
 

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
@@ -8,7 +8,6 @@ package org.swiften.redux.android.ui.recyclerview
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import org.swiften.redux.core.CompositeReduxSubscription
-import org.swiften.redux.ui.IActionDependency
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
 import org.swiften.redux.ui.IPropMapper
@@ -34,23 +33,20 @@ abstract class ReduxRecyclerViewAdapter<VH : RecyclerView.ViewHolder> : Recycler
 /**
  * [RecyclerView.Adapter] that delegates method calls to another [RecyclerView.Adapter].
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param LState The local state type that [GState] must extend from.
- * @param LExt See [IActionDependency.external]. [GExt] must extend from this parameter.
+ * @param OutProps Property as defined by [lifecycleOwner]'s parent.
  * @param VH The [RecyclerView.ViewHolder] instance.
  * @param VHState The [VH] state type. See [ReduxProps.state].
  * @param VHAction The [VH] action type. See [ReduxProps.action].
  * @param adapter The base [RecyclerView.Adapter] instance.
  */
-abstract class DelegateRecyclerAdapter<GState, GExt, LState, LExt, VH, VHState, VHAction>(
+abstract class DelegateRecyclerAdapter<GState, LState, OutProps, VH, VHState, VHAction>(
   private val adapter: RecyclerView.Adapter<VH>
 ) : RecyclerView.Adapter<VH>() where
   GState : LState,
-  GExt : LExt,
   LState : Any,
-  LExt : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, LExt, VHState, VHAction>,
+  VH : IPropContainer<LState, Pair<OutProps, Int>, VHState, VHAction>,
   VHState : Any,
   VHAction : Any {
   protected val composite = CompositeReduxSubscription("${this.javaClass}${Date().time}")
@@ -105,10 +101,9 @@ abstract class DelegateRecyclerAdapter<GState, GExt, LState, LExt, VH, VHState, 
   }
 
   /**
-   * Since we will be performing [IPropInjector.inject] for [VH] instances, we will be
-   * be using [CompositeReduxSubscription.add] a lot every time
-   * [RecyclerView.Adapter.onBindViewHolder] is called. As a result, calling this method will
-   * ensure proper deinitialization.
+   * Since we will be performing [IPropInjector.inject] for [VH] instances, we will be using
+   * [CompositeReduxSubscription.add] a lot every time [RecyclerView.Adapter.onBindViewHolder] is
+   * called. As a result, calling this method will ensure proper deinitialization.
    */
   internal fun unsubscribeSafely() = this.composite.unsubscribe()
 }
@@ -117,40 +112,42 @@ abstract class DelegateRecyclerAdapter<GState, GExt, LState, LExt, VH, VHState, 
  * Inject props for a [RecyclerView.Adapter] with a compatible [VH]. Note that this does not
  * support lifecycle handling, so we will need to manually set null via [RecyclerView.setAdapter]
  * in order to invoke [RecyclerView.Adapter.onViewRecycled], e.g. on orientation change.
+ *
+ * Note that [VH]'s outer props store both [OutProps] and [Int] corresponding to its layout
+ * position.
  * @return An [IPropInjector] instance.
  * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
  * @param LState The local state type that [GState] must extend from.
- * @param LExt See [IActionDependency.external]. [GExt] must extend from this parameter.
+ * @param OutProps Property as defined by [adapter]'s parent.
  * @param VH The [RecyclerView.ViewHolder] instance.
  * @param VHState The [VH] state type. See [ReduxProps.state].
  * @param VHAction The [VH] action type. See [ReduxProps.action].
  * @param adapter The base [RecyclerView.Adapter] instance.
+ * @param outProps An [OutProps] instance.
  * @param adapterMapper An [IStateMapper] instance that calculates item count for
  * [RecyclerView.Adapter.getItemCount].
  * @param vhMapper An [IPropMapper] instance for [VH].
  * @return A [DelegateRecyclerAdapter] instance.
  */
-fun <GState, GExt, LState, LExt, VH, VHState, VHAction> IPropInjector<GState, GExt>.injectRecyclerAdapter(
+fun <GState, LState, OutProps, VH, VHState, VHAction> IPropInjector<GState>.injectRecyclerAdapter(
   adapter: RecyclerView.Adapter<VH>,
+  outProps: OutProps,
   adapterMapper: IStateMapper<LState, Unit, Int>,
-  vhMapper: IPropMapper<LState, LExt, Int, VHState, VHAction>
-): DelegateRecyclerAdapter<GState, GExt, LState, LExt, VH, VHState, VHAction> where
+  vhMapper: IPropMapper<LState, Pair<OutProps, Int>, VHState, VHAction>
+): DelegateRecyclerAdapter<GState, LState, OutProps, VH, VHState, VHAction> where
   GState : LState,
-  GExt : LExt,
   LState : Any,
-  LExt : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, LExt, VHState, VHAction>,
+  VH : IPropContainer<LState, Pair<OutProps, Int>, VHState, VHAction>,
   VHState : Any,
   VHAction : Any {
-  return object : DelegateRecyclerAdapter<GState, GExt, LState, LExt, VH, VHState, VHAction>(adapter) {
+  return object : DelegateRecyclerAdapter<GState, LState, OutProps, VH, VHState, VHAction>(adapter) {
     override fun getItemCount(): Int {
       return adapterMapper.mapState(this@injectRecyclerAdapter.lastState(), Unit)
     }
 
     override fun onBindViewHolder(holder: VH, position: Int) {
-      val subscription = this@injectRecyclerAdapter.inject(holder, position, vhMapper)
+      val subscription = this@injectRecyclerAdapter.inject(holder, outProps to position, vhMapper)
       this.composite.add(subscription)
     }
 

--- a/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapterTest.kt
+++ b/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapterTest.kt
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.swiften.redux.android.ui.lifecycle.BaseLifecycleTest
-import org.swiften.redux.ui.IActionDependency
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProps
@@ -44,15 +44,15 @@ class DiffedAdapterTest : BaseLifecycleTest() {
     }
   }
 
-  class RecyclerAdapter : ReduxRecyclerViewAdapter<ViewHolder>(),
-    IPropMapper<Int, Unit, Unit, List<Int>, ViewHolder.A> by RecyclerAdapter,
-    IDiffItemCallback<Int> by RecyclerAdapter {
-    companion object : IPropMapper<Int, Unit, Unit, List<Int>, ViewHolder.A>, IDiffItemCallback<Int> {
+  class Adapter : ReduxRecyclerViewAdapter<ViewHolder>(),
+    IPropMapper<Int, Unit, List<Int>, ViewHolder.A> by Adapter,
+    IDiffItemCallback<Int> by Adapter {
+    companion object : IPropMapper<Int, Unit, List<Int>, ViewHolder.A>, IDiffItemCallback<Int> {
       override fun mapState(state: Int, outProps: Unit): List<Int> {
         return (0 until state).map { it }
       }
 
-      override fun mapAction(static: IActionDependency<Unit>, outProps: Unit): ViewHolder.A {
+      override fun mapAction(dispatch: IActionDispatcher, outProps: Unit): ViewHolder.A {
         return ViewHolder.A()
       }
 
@@ -76,10 +76,10 @@ class DiffedAdapterTest : BaseLifecycleTest() {
      */
     val injector = BaseLifecycleTest.TestInjector { totalItemCount }
     val lc = BaseLifecycleTest.TestLifecycleOwner()
-    val adapter = RecyclerAdapter()
+    val adapter = Adapter()
 
     // When
-    val wrappedAdapter = injector.injectDiffedAdapter(lc, adapter, RecyclerAdapter, RecyclerAdapter)
+    val wrappedAdapter = injector.injectDiffedAdapter(lc, adapter, Unit, Adapter, Adapter)
 
     // Then - adapter injection
     assertEquals(injector.injectionCount, 1)

--- a/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
+++ b/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.swiften.redux.android.ui.lifecycle.BaseLifecycleTest
-import org.swiften.redux.ui.IActionDependency
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper
@@ -31,17 +31,17 @@ import java.util.concurrent.atomic.AtomicInteger
 @RunWith(RobolectricTestRunner::class)
 class RecycleAdapterTest : BaseLifecycleTest() {
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
-    IPropContainer<Int, Unit, Int, Unit> {
-    companion object : IPropMapper<Int, Unit, Int, Int, Unit> {
-      override fun mapState(state: Int, outProps: Int) = state
-      override fun mapAction(static: IActionDependency<Unit>, outProps: Int) = Unit
+    IPropContainer<Int, Pair<Unit, Int>, Int, Unit> {
+    companion object : IPropMapper<Int, Pair<Unit, Int>, Int, Unit> {
+      override fun mapState(state: Int, outProps: Pair<Unit, Int>) = state
+      override fun mapAction(dispatch: IActionDispatcher, outProps: Pair<Unit, Int>) = Unit
     }
 
     override var reduxProps by ObservableReduxProps<Int, Unit> { _, _ -> }
   }
 
-  class RecyclerAdapter : ReduxRecyclerViewAdapter<ViewHolder>(),
-    IStateMapper<Int, Unit, Int> by RecyclerAdapter {
+  class Adapter : ReduxRecyclerViewAdapter<ViewHolder>(),
+    IStateMapper<Int, Unit, Int> by Adapter {
     companion object : IStateMapper<Int, Unit, Int> {
       val mapCount = AtomicInteger()
 
@@ -61,10 +61,10 @@ class RecycleAdapterTest : BaseLifecycleTest() {
     // Setup
     val injector = BaseLifecycleTest.TestInjector()
     val lc = BaseLifecycleTest.TestLifecycleOwner()
-    val adapter = RecyclerAdapter()
+    val adapter = Adapter()
 
     // When
-    val wrappedAdapter = injector.injectRecyclerAdapter(lc, adapter, RecyclerAdapter, ViewHolder)
+    val wrappedAdapter = injector.injectRecyclerAdapter(lc, adapter, Unit, Adapter, ViewHolder)
 
     // When - adapter mapper
     /** Every time itemCount is accessed, the adapter's state mapper should be triggered */
@@ -73,7 +73,7 @@ class RecycleAdapterTest : BaseLifecycleTest() {
     wrappedAdapter.itemCount
 
     // Then - adapter mapper
-    assertEquals(RecyclerAdapter.mapCount.get(), 3)
+    assertEquals(Adapter.mapCount.get(), 3)
 
     // When - view holder injection
     val viewGroup = LinearLayout(InstrumentationRegistry.getInstrumentation().context)

--- a/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
+++ b/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
@@ -31,10 +31,10 @@ import java.util.concurrent.atomic.AtomicInteger
 @RunWith(RobolectricTestRunner::class)
 class RecycleAdapterTest : BaseLifecycleTest() {
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
-    IPropContainer<Int, Pair<Unit, Int>, Int, Unit> {
-    companion object : IPropMapper<Int, Pair<Unit, Int>, Int, Unit> {
-      override fun mapState(state: Int, outProps: Pair<Unit, Int>) = state
-      override fun mapAction(dispatch: IActionDispatcher, outProps: Pair<Unit, Int>) = Unit
+    IPropContainer<Int, PositionProps<Unit>, Int, Unit> {
+    companion object : IPropMapper<Int, PositionProps<Unit>, Int, Unit> {
+      override fun mapState(state: Int, outProps: PositionProps<Unit>) = state
+      override fun mapAction(dispatch: IActionDispatcher, outProps: PositionProps<Unit>) = Unit
     }
 
     override var reduxProps by ObservableReduxProps<Int, Unit> { _, _ -> }

--- a/android/android-ui/src/main/java/org/swiften/redux/android/ui/AndroidPropInjector.kt
+++ b/android/android-ui/src/main/java/org/swiften/redux/android/ui/AndroidPropInjector.kt
@@ -19,29 +19,27 @@ import org.swiften.redux.ui.StaticProps
  * [PropInjector] specifically for Android that calls [inject] on the main thread. We use
  * inheritance here to ensure [StaticProps.injector] is set with this class instance.
  * @param GState The global state type.
- * @param GExt See [PropInjector.external].
  * @param store An [IReduxStore] instance.
  * @param external See [PropInjector.external].
  * @param runner An [AndroidUtil.IMainThreadRunner] instance.
  */
-class AndroidPropInjector<GState, GExt>(
+class AndroidPropInjector<GState>(
   store: IReduxStore<GState>,
-  external: GExt,
   private val runner: AndroidUtil.IMainThreadRunner = AndroidUtil.MainThreadRunner
-) : PropInjector<GState, GExt>(store, external) where GState : Any, GExt : Any {
-  override fun <LState, LExt, OutProps, State, Action> inject(
-    view: IPropContainer<LState, LExt, State, Action>,
+) : PropInjector<GState>(store) where GState : Any {
+  override fun <LState, OutProps, State, Action> inject(
+    view: IPropContainer<LState, OutProps, State, Action>,
     outProps: OutProps,
-    mapper: IPropMapper<LState, LExt, OutProps, State, Action>
-  ): IReduxSubscription where LState : Any, LExt : Any, State : Any, Action : Any {
-    return super.inject(object : IPropContainer<LState, LExt, State, Action> {
+    mapper: IPropMapper<LState, OutProps, State, Action>
+  ): IReduxSubscription where LState : Any, State : Any, Action : Any {
+    return super.inject(object : IPropContainer<LState, OutProps, State, Action> {
       override var reduxProps: ReduxProps<State, Action>
         get() = view.reduxProps
         set(value) {
           this@AndroidPropInjector.runner { view.reduxProps = value }
         }
 
-      override fun beforePropInjectionStarts(sp: StaticProps<LState, LExt>) {
+      override fun beforePropInjectionStarts(sp: StaticProps<LState, OutProps>) {
         this@AndroidPropInjector.runner { view.beforePropInjectionStarts(sp) }
       }
 

--- a/android/android-ui/src/test/java/org/swiften/redux/android/ui/AndroidInjectorTest.kt
+++ b/android/android-ui/src/test/java/org/swiften/redux/android/ui/AndroidInjectorTest.kt
@@ -67,8 +67,8 @@ class AndroidInjectorTest : PropInjectorTest() {
     override fun afterPropInjectionEnds() { this.afterInjectionCount.incrementAndGet() }
   }
 
-  override fun createInjector(store: IReduxStore<S>): IPropInjector<S, Unit> {
-    return AndroidPropInjector(store, Unit, this.runner)
+  override fun createInjector(store: IReduxStore<S>): IPropInjector<S> {
+    return AndroidPropInjector(store, this.runner)
   }
 
   @Test

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
@@ -20,13 +20,14 @@ interface IVariableProps<out State, out Action> where State : Any, Action : Any 
 
 /**
  * Container for an static dependencies.
- * @param GState The global state type.
- * @param GExt See [IPropInjector.external].
+ * @param LState The local state type that the global state must extend from.
+ * @param OutProps See [IPropInjector.external].
  * @param injector An [IPropInjector] instance.
  */
-data class StaticProps<GState, GExt>(
-  val injector: IPropInjector<GState, GExt>
-) where GState : Any, GExt : Any
+data class StaticProps<LState, OutProps>(
+  val injector: IPropInjector<LState>,
+  val outProps: OutProps
+) where LState : Any
 
 /**
  * Container for [s], [state] and [action].

--- a/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
+++ b/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.core.IReduxSubscriber
@@ -25,10 +26,9 @@ open class PropInjectorTest {
     data class SetQuery(val query: String) : Action()
   }
 
-  class TestInjector<GState, GExt>(
-    store: IReduxStore<GState>,
-    external: GExt
-  ) : PropInjector<GState, GExt>(store, external) where GState : Any, GExt : Any
+  class TestInjector<GState>(
+    store: IReduxStore<GState>
+  ) : PropInjector<GState>(store) where GState : Any
 
   class StoreWrapper(private val store: IReduxStore<S>) : IReduxStore<S> by store {
     val unsubscribeCount = AtomicInteger()
@@ -63,7 +63,7 @@ open class PropInjectorTest {
   }
 
   protected lateinit var store: StoreWrapper
-  protected lateinit var mapper: IPropMapper<S, Unit, Unit, S, A>
+  protected lateinit var mapper: IPropMapper<S, Unit, S, A>
 
   @Before
   open fun beforeMethod() {
@@ -78,14 +78,14 @@ open class PropInjectorTest {
 
     this.store = StoreWrapper(store)
 
-    this.mapper = object : IPropMapper<S, Unit, Unit, S, A> {
+    this.mapper = object : IPropMapper<S, Unit, S, A> {
       override fun mapState(state: S, outProps: Unit) = state
-      override fun mapAction(static: IActionDependency<Unit>, outProps: Unit) = A()
+      override fun mapAction(dispatch: IActionDispatcher, outProps: Unit) = A()
     }
   }
 
-  open fun createInjector(store: IReduxStore<S>): IPropInjector<S, Unit> {
-    return TestInjector(store, Unit)
+  open fun createInjector(store: IReduxStore<S>): IPropInjector<S> {
+    return TestInjector(store)
   }
 
   @Test

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainApplication.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainApplication.kt
@@ -33,7 +33,7 @@ class MainApplication : Application() {
       createThunkMiddleware(Unit)
     )(FinalStore(MainRedux.State(), MainRedux.Reducer))
 
-    val injector = AndroidPropInjector(store, Unit)
+    val injector = AndroidPropInjector(store)
 
     injector.injectActivitySerializable(this) {
       when (it) {

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainDependency.java
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainDependency.java
@@ -6,14 +6,13 @@
 package org.swiften.redux.android.sample;
 
 import androidx.annotation.NonNull;
-import kotlin.Unit;
 import org.swiften.redux.ui.IPropInjector;
 
 /** Created by haipham on 2018/12/19 */
 public final class MainDependency {
-  @NonNull final IPropInjector<MainRedux.State, Unit> injector;
+  @NonNull final IPropInjector<MainRedux.State> injector;
 
-  MainDependency(@NonNull IPropInjector<MainRedux.State, Unit> injector) {
+  MainDependency(@NonNull IPropInjector<MainRedux.State> injector) {
     this.injector = injector;
   }
 }

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MusicDetailFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MusicDetailFragment.kt
@@ -13,7 +13,7 @@ import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_music_detail.artistName
 import kotlinx.android.synthetic.main.fragment_music_detail.trackName
 import kotlinx.android.synthetic.main.fragment_music_detail.trackOpen
-import org.swiften.redux.ui.IActionDependency
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProps
@@ -25,9 +25,9 @@ class MusicDetailFragment : Fragment(),
   class S(val track: MusicTrack?)
   class A(val previewTrack: () -> Unit)
 
-  companion object : IPropMapper<MainRedux.State, Unit, Unit, S, A> {
-    override fun mapAction(static: IActionDependency<Unit>, outProps: Unit): A {
-      return A { static.dispatch(MainRedux.ThunkAction.PreviewTrack) }
+  companion object : IPropMapper<MainRedux.State, Unit, S, A> {
+    override fun mapAction(dispatch: IActionDispatcher, outProps: Unit): A {
+      return A { dispatch(MainRedux.ThunkAction.PreviewTrack) }
     }
 
     override fun mapState(state: MainRedux.State, outProps: Unit) = S(state.currentSelectedTrack())

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/SearchFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/SearchFragment.kt
@@ -24,7 +24,7 @@ import kotlinx.android.synthetic.main.view_search_result.view.trackName
 import org.swiften.redux.android.ui.recyclerview.IDiffItemCallback
 import org.swiften.redux.android.ui.recyclerview.ReduxRecyclerViewAdapter
 import org.swiften.redux.android.ui.recyclerview.injectDiffedAdapter
-import org.swiften.redux.ui.IActionDependency
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProps
@@ -38,7 +38,7 @@ class SearchFragment : Fragment(),
 
   class Adapter : ReduxRecyclerViewAdapter<ViewHolder>() {
     companion object :
-      IPropMapper<MainRedux.State, Unit, Unit, List<ViewHolder.S1>, ViewHolder.A1>,
+      IPropMapper<MainRedux.State, Unit, List<ViewHolder.S1>, ViewHolder.A1>,
       IDiffItemCallback<ViewHolder.S1> {
       override fun mapState(state: MainRedux.State, outProps: Unit): List<ViewHolder.S1> {
         return state.musicResult?.results
@@ -46,8 +46,8 @@ class SearchFragment : Fragment(),
           ?: arrayListOf()
       }
 
-      override fun mapAction(static: IActionDependency<Unit>, outProps: Unit): ViewHolder.A1 {
-        return ViewHolder.A1 { static.dispatch(MainRedux.Screen.MusicDetail(it)) }
+      override fun mapAction(dispatch: IActionDispatcher, outProps: Unit): ViewHolder.A1 {
+        return ViewHolder.A1 { dispatch(MainRedux.Screen.MusicDetail(it)) }
       }
 
       override fun areItemsTheSame(oldItem: ViewHolder.S1, newItem: ViewHolder.S1): Boolean {
@@ -91,9 +91,9 @@ class SearchFragment : Fragment(),
     }
   }
 
-  companion object : IPropMapper<MainRedux.State, Unit, Unit, S, A> {
-    override fun mapAction(static: IActionDependency<Unit>, outProps: Unit): A {
-      return A { static.dispatch(MainRedux.Action.UpdateAutocompleteQuery(it)) }
+  companion object : IPropMapper<MainRedux.State, Unit, S, A> {
+    override fun mapAction(dispatch: IActionDispatcher, outProps: Unit): A {
+      return A { dispatch(MainRedux.Action.UpdateAutocompleteQuery(it)) }
     }
 
     override fun mapState(state: MainRedux.State, outProps: Unit): S {
@@ -133,7 +133,7 @@ class SearchFragment : Fragment(),
     this.searchResult.also {
       it.setHasFixedSize(true)
       it.layoutManager = LinearLayoutManager(this.context)
-      it.adapter = sp.injector.injectDiffedAdapter(this, Adapter(), Adapter, Adapter)
+      it.adapter = sp.injector.injectDiffedAdapter(this, Adapter(), Unit, Adapter, Adapter)
     }
   }
 }

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenApplication.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenApplication.kt
@@ -46,13 +46,13 @@ class GardenApplication : Application() {
       createThunkMiddleware(dependency)
     )(FinalStore(Redux.State(), Redux.Reducer))
 
-    val injector = AndroidPropInjector(store, dependency)
+    val injector = AndroidPropInjector(store)
 
     injector.injectActivityParcelable(this) {
       when (it) {
-        is GardenFragment -> this.injectLifecycle(it, Unit, GardenFragment)
-        is PlantDetailFragment -> this.injectLifecycle(it, Unit, PlantDetailFragment)
-        is PlantListFragment -> this.injectLifecycle(it, Unit, PlantListFragment)
+        is GardenFragment -> this.injectLifecycle(it, dependency, GardenFragment)
+        is PlantDetailFragment -> this.injectLifecycle(it, dependency, PlantDetailFragment)
+        is PlantListFragment -> this.injectLifecycle(it, dependency, PlantListFragment)
         else -> Unit
       }
     }

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -26,7 +26,7 @@ import com.google.samples.apps.sunflower.dependency.Redux
 import kotlinx.android.synthetic.main.fragment_garden.empty_garden
 import kotlinx.android.synthetic.main.fragment_garden.garden_list
 import org.swiften.redux.android.ui.recyclerview.injectRecyclerAdapter
-import org.swiften.redux.ui.IActionDependency
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProps
@@ -38,9 +38,12 @@ class GardenFragment : Fragment(),
 
   data class S(val gardenPlantingCount: Int)
 
-  companion object : IPropMapper<Redux.State, IDependency, Unit, S, Unit> {
-    override fun mapAction(static: IActionDependency<IDependency>, outProps: Unit) = Unit
-    override fun mapState(state: Redux.State, outProps: Unit) = S(state.gardenPlantings?.size ?: 0)
+  companion object : IPropMapper<Redux.State, IDependency, S, Unit> {
+    override fun mapAction(dispatch: IActionDispatcher, outProps: IDependency) = Unit
+
+    override fun mapState(state: Redux.State, outProps: IDependency): S {
+      return S(state.gardenPlantings?.size ?: 0)
+    }
   }
 
   override var reduxProps by ObservableReduxProps<S, Unit> { prev, next ->
@@ -67,7 +70,7 @@ class GardenFragment : Fragment(),
 
   override fun beforePropInjectionStarts(sp: StaticProps<Redux.State, IDependency>) {
     this.garden_list.adapter = GardenPlantingAdapter().let {
-      sp.injector.injectRecyclerAdapter(this, it, it, GardenPlantingAdapter.ViewHolder)
+      sp.injector.injectRecyclerAdapter(this, it, sp.outProps, it, GardenPlantingAdapter.ViewHolder)
     }
   }
 }

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -44,7 +44,7 @@ import kotlinx.android.synthetic.main.fragment_plant_detail.fab
 import kotlinx.android.synthetic.main.fragment_plant_detail.plant_detail
 import kotlinx.android.synthetic.main.fragment_plant_detail.plant_watering
 import kotlinx.android.synthetic.main.fragment_plant_detail.toolbar_layout
-import org.swiften.redux.ui.IActionDependency
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProps
@@ -61,17 +61,15 @@ class PlantDetailFragment : Fragment(),
   data class S(val plant: Plant? = null, val isPlanted: Boolean? = null)
   class A(override val picasso: Picasso, val addPlantToGarden: () -> Unit) : IPicassoProvider
 
-  companion object : IPropMapper<Redux.State, IDependency, Unit, S, A> {
-    override fun mapState(state: Redux.State, outProps: Unit): S {
+  companion object : IPropMapper<Redux.State, IDependency, S, A> {
+    override fun mapState(state: Redux.State, outProps: IDependency): S {
       return state.selectedPlant?.let {
         S(it.id.let { id -> state.plants?.find { p -> p.plantId == id } }, it.isPlanted)
       } ?: S()
     }
 
-    override fun mapAction(static: IActionDependency<IDependency>, outProps: Unit): A {
-      return A(static.external.picasso) {
-        static.dispatch(Redux.ThunkAction.AddSelectedPlantToGarden)
-      }
+    override fun mapAction(dispatch: IActionDispatcher, outProps: IDependency): A {
+      return A(outProps.picasso) { dispatch(Redux.ThunkAction.AddSelectedPlantToGarden) }
     }
   }
 

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -28,7 +28,7 @@ import com.google.samples.apps.sunflower.adapters.PlantAdapter
 import com.google.samples.apps.sunflower.dependency.Redux
 import kotlinx.android.synthetic.main.fragment_plant_list.plant_list
 import org.swiften.redux.android.ui.recyclerview.injectDiffedAdapter
-import org.swiften.redux.ui.IActionDependency
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProps
@@ -41,13 +41,13 @@ class PlantListFragment : Fragment(),
   data class S(val plantCount: Int)
   class A(val updateGrowZone: () -> Unit)
 
-  companion object : IPropMapper<Redux.State, IDependency, Unit, S, A> {
-    override fun mapState(state: Redux.State, outProps: Unit): S {
+  companion object : IPropMapper<Redux.State, IDependency, S, A> {
+    override fun mapState(state: Redux.State, outProps: IDependency): S {
       return S(plantCount = state.plants?.size ?: 0)
     }
 
-    override fun mapAction(static: IActionDependency<IDependency>, outProps: Unit): A {
-      return A { static.dispatch(Redux.ThunkAction.ToggleGrowZone(9)) }
+    override fun mapAction(dispatch: IActionDispatcher, outProps: IDependency): A {
+      return A { dispatch(Redux.ThunkAction.ToggleGrowZone(9)) }
     }
   }
 
@@ -83,6 +83,6 @@ class PlantListFragment : Fragment(),
 
   override fun beforePropInjectionStarts(sp: StaticProps<Redux.State, IDependency>) {
     this.plant_list.adapter = sp.injector
-      .injectDiffedAdapter(this, PlantAdapter(), PlantAdapter, PlantAdapter)
+      .injectDiffedAdapter(this, PlantAdapter(), sp.outProps, PlantAdapter, PlantAdapter)
   }
 }

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
@@ -28,6 +28,7 @@ import com.google.samples.apps.sunflower.dependency.IPicassoProvider
 import com.google.samples.apps.sunflower.dependency.Redux
 import com.google.samples.apps.sunflower.utilities.SMALL_IMAGE_DIMEN
 import com.squareup.picasso.Picasso
+import org.swiften.redux.android.ui.recyclerview.PositionProps
 import org.swiften.redux.android.ui.recyclerview.ReduxRecyclerViewAdapter
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
@@ -54,18 +55,18 @@ class GardenPlantingAdapter : ReduxRecyclerViewAdapter<GardenPlantingAdapter.Vie
   }
 
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
-    IPropContainer<Redux.State, Pair<IDependency, Int>, ViewHolder.S, ViewHolder.A> {
+    IPropContainer<Redux.State, PositionProps<IDependency>, ViewHolder.S, ViewHolder.A> {
     data class S(val plantings: PlantAndGardenPlantings?)
     class A(override val picasso: Picasso, val goToPlantDetail: () -> Unit) : IPicassoProvider
 
-    companion object : IPropMapper<Redux.State, Pair<IDependency, Int>, S, A> {
-      override fun mapState(state: Redux.State, outProps: Pair<IDependency, Int>): S {
-        return S(state.plantAndGardenPlantings?.elementAtOrNull(outProps.second))
+    companion object : IPropMapper<Redux.State, PositionProps<IDependency>, S, A> {
+      override fun mapState(state: Redux.State, outProps: PositionProps<IDependency>): S {
+        return S(state.plantAndGardenPlantings?.elementAtOrNull(outProps.position))
       }
 
-      override fun mapAction(dispatch: IActionDispatcher, outProps: Pair<IDependency, Int>): A {
-        return A(outProps.first.picasso) {
-          dispatch(Redux.Action.SelectPlantFromGarden(outProps.second))
+      override fun mapAction(dispatch: IActionDispatcher, outProps: PositionProps<IDependency>): A {
+        return A(outProps.external.picasso) {
+          dispatch(Redux.Action.SelectPlantFromGarden(outProps.position))
         }
       }
     }
@@ -104,7 +105,7 @@ class GardenPlantingAdapter : ReduxRecyclerViewAdapter<GardenPlantingAdapter.Vie
     private val plantDate: TextView = this.itemView.findViewById(R.id.plant_date)
     private val waterDate: TextView = this.itemView.findViewById(R.id.water_date)
 
-    override fun beforePropInjectionStarts(sp: StaticProps<Redux.State, Pair<IDependency, Int>>) {
+    override fun beforePropInjectionStarts(sp: StaticProps<Redux.State, PositionProps<IDependency>>) {
       this.itemView.setOnClickListener {
         this@ViewHolder.reduxProps.action?.goToPlantDetail?.invoke()
       }

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
@@ -29,7 +29,7 @@ import com.google.samples.apps.sunflower.dependency.Redux
 import com.google.samples.apps.sunflower.utilities.SMALL_IMAGE_DIMEN
 import com.squareup.picasso.Picasso
 import org.swiften.redux.android.ui.recyclerview.ReduxRecyclerViewAdapter
-import org.swiften.redux.ui.IActionDependency
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper
@@ -54,18 +54,18 @@ class GardenPlantingAdapter : ReduxRecyclerViewAdapter<GardenPlantingAdapter.Vie
   }
 
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
-    IPropContainer<Redux.State, IDependency, ViewHolder.S, ViewHolder.A> {
+    IPropContainer<Redux.State, Pair<IDependency, Int>, ViewHolder.S, ViewHolder.A> {
     data class S(val plantings: PlantAndGardenPlantings?)
     class A(override val picasso: Picasso, val goToPlantDetail: () -> Unit) : IPicassoProvider
 
-    companion object : IPropMapper<Redux.State, IDependency, Int, S, A> {
-      override fun mapState(state: Redux.State, outProps: Int): S {
-        return S(state.plantAndGardenPlantings?.elementAtOrNull(outProps))
+    companion object : IPropMapper<Redux.State, Pair<IDependency, Int>, S, A> {
+      override fun mapState(state: Redux.State, outProps: Pair<IDependency, Int>): S {
+        return S(state.plantAndGardenPlantings?.elementAtOrNull(outProps.second))
       }
 
-      override fun mapAction(static: IActionDependency<IDependency>, outProps: Int): A {
-        return A(static.external.picasso) {
-          static.dispatch(Redux.Action.SelectPlantFromGarden(outProps))
+      override fun mapAction(dispatch: IActionDispatcher, outProps: Pair<IDependency, Int>): A {
+        return A(outProps.first.picasso) {
+          dispatch(Redux.Action.SelectPlantFromGarden(outProps.second))
         }
       }
     }
@@ -104,7 +104,7 @@ class GardenPlantingAdapter : ReduxRecyclerViewAdapter<GardenPlantingAdapter.Vie
     private val plantDate: TextView = this.itemView.findViewById(R.id.plant_date)
     private val waterDate: TextView = this.itemView.findViewById(R.id.water_date)
 
-    override fun beforePropInjectionStarts(sp: StaticProps<Redux.State, IDependency>) {
+    override fun beforePropInjectionStarts(sp: StaticProps<Redux.State, Pair<IDependency, Int>>) {
       this.itemView.setOnClickListener {
         this@ViewHolder.reduxProps.action?.goToPlantDetail?.invoke()
       }

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
@@ -31,7 +31,7 @@ import com.google.samples.apps.sunflower.utilities.SMALL_IMAGE_DIMEN
 import com.squareup.picasso.Picasso
 import org.swiften.redux.android.ui.recyclerview.IDiffItemCallback
 import org.swiften.redux.android.ui.recyclerview.ReduxRecyclerViewAdapter
-import org.swiften.redux.ui.IActionDependency
+import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProps
@@ -43,13 +43,15 @@ class PlantAdapter : ReduxRecyclerViewAdapter<PlantAdapter.ViewHolder>() {
   interface IDependency : IPicassoProvider
 
   companion object :
-    IPropMapper<Redux.State, IDependency, Unit, List<Plant>, ViewHolder.A>,
+    IPropMapper<Redux.State, IDependency, List<Plant>, ViewHolder.A>,
     IDiffItemCallback<Plant> {
-    override fun mapState(state: Redux.State, outProps: Unit) = state.plants ?: arrayListOf()
+    override fun mapState(state: Redux.State, outProps: IDependency): List<Plant> {
+      return state.plants ?: arrayListOf()
+    }
 
-    override fun mapAction(static: IActionDependency<IDependency>, outProps: Unit): ViewHolder.A {
-      return ViewHolder.A(static.external.picasso) { index ->
-        static.dispatch(Redux.Action.SelectPlantFromPlantList(index))
+    override fun mapAction(dispatch: IActionDispatcher, outProps: IDependency): ViewHolder.A {
+      return ViewHolder.A(outProps.picasso) { index ->
+        dispatch(Redux.Action.SelectPlantFromPlantList(index))
       }
     }
 


### PR DESCRIPTION
Replace GExt and LExt with OutProps. Dependencies can be passed via OutProps from parent to child, which is directly comparable to React.js' parent-child relationship.