### PR TITLE
Dispatch job for IActionDispatcher

### DIFF
--- a/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
+++ b/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
@@ -8,6 +8,7 @@ package org.swiften.redux.android.ui.lifecycle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IDeinitializer
 import org.swiften.redux.core.IReduxSubscription
@@ -72,7 +73,7 @@ open class BaseLifecycleTest {
       return subscription
     }
 
-    override val dispatch: IActionDispatcher = {}
+    override val dispatch: IActionDispatcher = { EmptyDispatchJob }
     override val deinitialize: IDeinitializer = {}
   }
 }

--- a/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
+++ b/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
@@ -8,7 +8,7 @@ package org.swiften.redux.android.ui.lifecycle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IDeinitializer
 import org.swiften.redux.core.IReduxSubscription
@@ -73,7 +73,7 @@ open class BaseLifecycleTest {
       return subscription
     }
 
-    override val dispatch: IActionDispatcher = { EmptyDispatchJob }
+    override val dispatch: IActionDispatcher = { EmptyJob }
     override val deinitialize: IDeinitializer = {}
   }
 }

--- a/android/android-livedata-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/livedata/TakeEveryEffect.kt
+++ b/android/android-livedata-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/livedata/TakeEveryEffect.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.Observer
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
@@ -39,6 +40,6 @@ internal class TakeEveryEffect<R>(private val creator: () -> LiveData<R>) : Saga
       .toFlowable(BackpressureStrategy.BUFFER)
       .serialize()
 
-    return SagaOutput(p1.scope, stream) { }
+    return SagaOutput(p1.scope, stream) { EmptyDispatchJob }
   }
 }

--- a/android/android-livedata-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/livedata/TakeEveryEffect.kt
+++ b/android/android-livedata-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/livedata/TakeEveryEffect.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.Observer
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
@@ -40,6 +40,6 @@ internal class TakeEveryEffect<R>(private val creator: () -> LiveData<R>) : Saga
       .toFlowable(BackpressureStrategy.BUFFER)
       .serialize()
 
-    return SagaOutput(p1.scope, stream) { EmptyDispatchJob }
+    return SagaOutput(p1.scope, stream) { EmptyJob }
   }
 }

--- a/android/android-livedata-rx-saga/src/test/java/org/swiften/redux/android/saga/rx/livedata/LiveDataEffectTest.kt
+++ b/android/android-livedata-rx-saga/src/test/java/org/swiften/redux/android/saga/rx/livedata/LiveDataEffectTest.kt
@@ -7,7 +7,6 @@ package org.swiften.redux.android.saga.rx.livedata
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -39,7 +38,7 @@ class LiveDataEffectTest {
     takeEveryData { data }
       .mapAsync { this.async { delay(1000); it } }
       .filter { it % 2 == 0 }
-      .invoke(GlobalScope, 0) { }
+      .invoke()
       .subscribe({ finalValues.add(it) })
 
     // When

--- a/android/android-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/core/WatchConnectivityEffect.kt
+++ b/android/android-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/core/WatchConnectivityEffect.kt
@@ -16,6 +16,7 @@ import android.net.NetworkRequest
 import android.os.Build
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
@@ -66,6 +67,6 @@ internal class WatchConnectivityEffect(private val context: Context) : SagaEffec
       }
     }
 
-    return SagaOutput(p1.scope, stream.toFlowable(BackpressureStrategy.BUFFER)) { }
+    return SagaOutput(p1.scope, stream.toFlowable(BackpressureStrategy.BUFFER)) { EmptyDispatchJob }
   }
 }

--- a/android/android-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/core/WatchConnectivityEffect.kt
+++ b/android/android-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/core/WatchConnectivityEffect.kt
@@ -16,7 +16,7 @@ import android.net.NetworkRequest
 import android.os.Build
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
@@ -67,6 +67,6 @@ internal class WatchConnectivityEffect(private val context: Context) : SagaEffec
       }
     }
 
-    return SagaOutput(p1.scope, stream.toFlowable(BackpressureStrategy.BUFFER)) { EmptyDispatchJob }
+    return SagaOutput(p1.scope, stream.toFlowable(BackpressureStrategy.BUFFER)) { EmptyJob }
   }
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncJob.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncJob.kt
@@ -15,12 +15,12 @@ import kotlin.coroutines.CoroutineContext
 /** Represents a job that does some asynchronous work and can be resolved synchronously. */
 interface IAsyncJob {
   /** Wait until some asynchronous action finishes. */
-  fun blockingWait()
+  fun await()
 }
 
 /** Represents an empty [IAsyncJob] that does not do anything. */
 object EmptyJob : IAsyncJob {
-  override fun blockingWait() {}
+  override fun await() {}
 }
 
 /**
@@ -38,7 +38,7 @@ class CoroutineJob(
     performer: suspend CoroutineContext.() -> Unit
   ) : this(context, GlobalScope.launch(context) { performer(context) })
 
-  override fun blockingWait() {
+  override fun await() {
     val latch = CountDownLatch(1)
 
     GlobalScope.launch(this.context) {

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncMiddleware.kt
@@ -21,8 +21,8 @@ internal class AsyncMiddleware(private val context: CoroutineContext) : IMiddlew
 
       DispatchWrapper.wrap(wrapper, "async") { action ->
         when (action) {
-          is DefaultReduxAction.Deinitialize -> { context.cancel(); EmptyDispatchJob }
-          else -> CoroutineDispatchJob(context) { wrapper.dispatch(action) } }
+          is DefaultReduxAction.Deinitialize -> { context.cancel(); EmptyJob }
+          else -> CoroutineJob(context) { wrapper.dispatch(action) } }
       }
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncMiddleware.kt
@@ -5,10 +5,8 @@
 
 package org.swiften.redux.core
 
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 
 /** Created by haipham on 2019/01/26 */
@@ -19,12 +17,12 @@ import kotlin.coroutines.CoroutineContext
 internal class AsyncMiddleware(private val context: CoroutineContext) : IMiddleware<Any> {
   override fun invoke(p1: MiddlewareInput<Any>): DispatchMapper {
     return { wrapper ->
-      println(wrapper)
+      val context = this@AsyncMiddleware.context
+
       DispatchWrapper.wrap(wrapper, "async") { action ->
         when (action) {
-          is DefaultReduxAction.Deinitialize -> this@AsyncMiddleware.context.cancel()
-          else -> GlobalScope.launch(this@AsyncMiddleware.context) { wrapper.dispatch(action) }
-        }
+          is DefaultReduxAction.Deinitialize -> { context.cancel(); EmptyDispatchJob }
+          else -> CoroutineDispatchJob(context) { wrapper.dispatch(action) } }
       }
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
@@ -7,7 +7,7 @@ package org.swiften.redux.core
 
 /** Created by haipham on 2018/03/31 */
 /** Represents an [IReduxAction] dispatcher. */
-typealias IActionDispatcher = (IReduxAction) -> Any
+typealias IActionDispatcher = (IReduxAction) -> IDispatchJob
 
 /**
  * Represents a Redux reducer that reduce a [IReduxAction] onto a previous state to produce a new

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
@@ -7,7 +7,7 @@ package org.swiften.redux.core
 
 /** Created by haipham on 2018/03/31 */
 /** Represents an [IReduxAction] dispatcher. */
-typealias IActionDispatcher = (IReduxAction) -> IDispatchJob
+typealias IActionDispatcher = (IReduxAction) -> IAsyncJob
 
 /**
  * Represents a Redux reducer that reduce a [IReduxAction] onto a previous state to produce a new

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchJob.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchJob.kt
@@ -36,6 +36,11 @@ class CoroutineDispatchJob(
   private val context: CoroutineContext,
   private val job: Job
 ) : IDispatchJob {
+  constructor(
+    context: CoroutineContext,
+    performer: suspend CoroutineContext.() -> Unit
+  ) : this(context, GlobalScope.launch(context) { performer(context) })
+
   override fun blockingWait() {
     val latch = CountDownLatch(1)
 

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchJob.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchJob.kt
@@ -12,30 +12,27 @@ import java.util.concurrent.CountDownLatch
 import kotlin.coroutines.CoroutineContext
 
 /** Created by haipham on 2019/02/16 */
-/**
- * Represents a job for [IActionDispatcher] that can be resolved to ensure [IReduxStore.dispatch]
- * finishes mutating internal state.
- */
-interface IDispatchJob {
+/** Represents a job that does some asynchronous work and can be resolved synchronously. */
+interface IAsyncJob {
   /** Wait until some asynchronous action finishes. */
   fun blockingWait()
 }
 
-/** Represents an empty [IDispatchJob] that does not do anything. */
-object EmptyDispatchJob : IDispatchJob {
+/** Represents an empty [IAsyncJob] that does not do anything. */
+object EmptyJob : IAsyncJob {
   override fun blockingWait() {}
 }
 
 /**
- * Represents an [IDispatchJob] that handles [Job]. It waits for [job] to resolve synchronously
- * with a [CountDownLatch].
+ * Represents an [IAsyncJob] that handles [Job]. It waits for [job] to resolve synchronously with
+ * a [CountDownLatch].
  * @param context A [CoroutineContext] instance.
  * @param job The [Job] to be resolved.
  */
-class CoroutineDispatchJob(
+class CoroutineJob(
   private val context: CoroutineContext,
   private val job: Job
-) : IDispatchJob {
+) : IAsyncJob {
   constructor(
     context: CoroutineContext,
     performer: suspend CoroutineContext.() -> Unit
@@ -45,7 +42,7 @@ class CoroutineDispatchJob(
     val latch = CountDownLatch(1)
 
     GlobalScope.launch(this.context) {
-      this@CoroutineDispatchJob.job.join()
+      this@CoroutineJob.job.join()
       latch.countDown()
     }
 

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchJob.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchJob.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) haipham 2019. All rights reserved.
+ * Any attempt to reproduce this source code in any form shall be met with legal actions.
+ */
+
+package org.swiften.redux.core
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.util.concurrent.CountDownLatch
+import kotlin.coroutines.CoroutineContext
+
+/** Created by haipham on 2019/02/16 */
+/**
+ * Represents a job for [IActionDispatcher] that can be resolved to ensure [IReduxStore.dispatch]
+ * finishes mutating internal state.
+ */
+interface IDispatchJob {
+  /** Wait until some asynchronous action finishes. */
+  fun blockingWait()
+}
+
+/** Represents an empty [IDispatchJob] that does not do anything. */
+object EmptyDispatchJob : IDispatchJob {
+  override fun blockingWait() {}
+}
+
+/**
+ * Represents an [IDispatchJob] that handles [Job]. It waits for [job] to resolve synchronously
+ * with a [CountDownLatch].
+ * @param context A [CoroutineContext] instance.
+ * @param job The [Job] to be resolved.
+ */
+class CoroutineDispatchJob(
+  private val context: CoroutineContext,
+  private val job: Job
+) : IDispatchJob {
+  override fun blockingWait() {
+    val latch = CountDownLatch(1)
+
+    GlobalScope.launch(this.context) {
+      this@CoroutineDispatchJob.job.join()
+      latch.countDown()
+    }
+
+    latch.await()
+  }
+}

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
@@ -58,6 +58,8 @@ internal class RouterMiddleware<Screen>(
         if (action == DefaultReduxAction.Deinitialize) {
           this@RouterMiddleware.router.deinitialize()
         }
+
+        EmptyDispatchJob
       }
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
@@ -59,7 +59,7 @@ internal class RouterMiddleware<Screen>(
           this@RouterMiddleware.router.deinitialize()
         }
 
-        EmptyDispatchJob
+        EmptyJob
       }
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
@@ -29,6 +29,7 @@ class ThreadSafeStore<GState>(
   override val dispatch: IActionDispatcher = { action ->
     this.lock.write { this.state = this.reducer(this.state, action) }
     this.lock.read { this.subscribers.forEach { it.value(this.state) } }
+    EmptyDispatchJob
   }
 
   override val subscribe: IReduxSubscriber<GState> = { id, callback ->

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
@@ -29,7 +29,7 @@ class ThreadSafeStore<GState>(
   override val dispatch: IActionDispatcher = { action ->
     this.lock.write { this.state = this.reducer(this.state, action) }
     this.lock.read { this.subscribers.forEach { it.value(this.state) } }
-    EmptyDispatchJob
+    EmptyJob
   }
 
   override val subscribe: IReduxSubscriber<GState> = { id, callback ->

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncMiddlewareTest.kt
@@ -21,7 +21,7 @@ class AsyncMiddlewareTest : BaseMiddlewareTest() {
     val dispatched = AtomicInteger(0)
     val job = Job()
     val middleware = createAsyncMiddleware(job)
-    val dispatch: IActionDispatcher = { dispatched.incrementAndGet(); EmptyDispatchJob }
+    val dispatch: IActionDispatcher = { dispatched.incrementAndGet(); EmptyJob }
     val dispatchWrapper = this.mockDispatchWrapper(dispatch)
     val input = mockMiddlewareInput(0)
     val wrappedDispatch = middleware(input)(dispatchWrapper).dispatch

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncMiddlewareTest.kt
@@ -21,7 +21,7 @@ class AsyncMiddlewareTest : BaseMiddlewareTest() {
     val dispatched = AtomicInteger(0)
     val job = Job()
     val middleware = createAsyncMiddleware(job)
-    val dispatch: IActionDispatcher = { dispatched.incrementAndGet() }
+    val dispatch: IActionDispatcher = { dispatched.incrementAndGet(); EmptyDispatchJob }
     val dispatchWrapper = this.mockDispatchWrapper(dispatch)
     val input = mockMiddlewareInput(0)
     val wrappedDispatch = middleware(input)(dispatchWrapper).dispatch

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseMiddlewareTest.kt
@@ -9,10 +9,10 @@ package org.swiften.redux.core
 /** Mock test class to provide some utilities */
 open class BaseMiddlewareTest {
   fun <GState> mockMiddlewareInput(state: GState): MiddlewareInput<GState> {
-    return MiddlewareInput({}, { state }, { _, _ -> ReduxSubscription.EMPTY })
+    return MiddlewareInput({ EmptyDispatchJob }, { state }, { _, _ -> ReduxSubscription.EMPTY })
   }
 
-  fun mockDispatchWrapper(dispatch: IActionDispatcher = {}): DispatchWrapper {
+  fun mockDispatchWrapper(dispatch: IActionDispatcher = { EmptyDispatchJob }): DispatchWrapper {
     return DispatchWrapper.root(dispatch)
   }
 }

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseMiddlewareTest.kt
@@ -9,10 +9,10 @@ package org.swiften.redux.core
 /** Mock test class to provide some utilities */
 open class BaseMiddlewareTest {
   fun <GState> mockMiddlewareInput(state: GState): MiddlewareInput<GState> {
-    return MiddlewareInput({ EmptyDispatchJob }, { state }, { _, _ -> ReduxSubscription.EMPTY })
+    return MiddlewareInput({ EmptyJob }, { state }, { _, _ -> ReduxSubscription.EMPTY })
   }
 
-  fun mockDispatchWrapper(dispatch: IActionDispatcher = { EmptyDispatchJob }): DispatchWrapper {
+  fun mockDispatchWrapper(dispatch: IActionDispatcher = { EmptyJob }): DispatchWrapper {
     return DispatchWrapper.root(dispatch)
   }
 }

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/MiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/MiddlewareTest.kt
@@ -18,9 +18,9 @@ class MiddlewareTest : BaseMiddlewareTest() {
     val order = arrayListOf<Int>()
 
     val wrappedStore = applyMiddlewares<Int>(
-      { { w -> DispatchWrapper.wrap(w, "1") { w.dispatch(it); order.add(1); EmptyDispatchJob } } },
-      { { w -> DispatchWrapper.wrap(w, "2") { w.dispatch(it); order.add(2); EmptyDispatchJob } } },
-      { { w -> DispatchWrapper.wrap(w, "3") { w.dispatch(it); order.add(3); EmptyDispatchJob } } }
+      { { w -> DispatchWrapper.wrap(w, "1") { w.dispatch(it); order.add(1); EmptyJob } } },
+      { { w -> DispatchWrapper.wrap(w, "2") { w.dispatch(it); order.add(2); EmptyJob } } },
+      { { w -> DispatchWrapper.wrap(w, "3") { w.dispatch(it); order.add(3); EmptyJob } } }
     )(store)
 
     // When
@@ -44,12 +44,12 @@ class MiddlewareTest : BaseMiddlewareTest() {
       { { w -> DispatchWrapper.wrap(w, "1") {
         w.dispatch(it)
         if (it is RepeatAction) repeatCount.incrementAndGet()
-        EmptyDispatchJob
+        EmptyJob
       } } },
       { i -> { w -> DispatchWrapper.wrap(w, "2") {
         w.dispatch(it)
         if (it is TriggerAction) i.dispatch(RepeatAction())
-        EmptyDispatchJob
+        EmptyJob
       } } }
     )(store)
 

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/CallEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/CallEffect.kt
@@ -6,6 +6,7 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Single
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
@@ -24,6 +25,6 @@ internal class CallEffect<P, R>(
   private val transformer: (P) -> Single<R>
 ) : SagaEffect<R>() where P : Any, R : Any {
   override fun invoke(p1: SagaInput) = this.source.invoke(p1).flatMap {
-    SagaOutput(p1.scope, this.transformer(it).toFlowable()) { }
+    SagaOutput(p1.scope, this.transformer(it).toFlowable()) { EmptyDispatchJob }
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/CallEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/CallEffect.kt
@@ -6,7 +6,7 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Single
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
@@ -25,6 +25,6 @@ internal class CallEffect<P, R>(
   private val transformer: (P) -> Single<R>
 ) : SagaEffect<R>() where P : Any, R : Any {
   override fun invoke(p1: SagaInput) = this.source.invoke(p1).flatMap {
-    SagaOutput(p1.scope, this.transformer(it).toFlowable()) { EmptyDispatchJob }
+    SagaOutput(p1.scope, this.transformer(it).toFlowable()) { EmptyJob }
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/FromEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/FromEffect.kt
@@ -6,6 +6,7 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Flowable
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
 
@@ -18,5 +19,5 @@ import org.swiften.redux.saga.common.SagaInput
 internal class FromEffect<R>(
   private val stream: Flowable<R>
 ) : SagaEffect<R>() where R : Any {
-  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, this.stream) { }
+  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, this.stream) { EmptyDispatchJob }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/FromEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/FromEffect.kt
@@ -6,7 +6,7 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Flowable
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
 
@@ -19,5 +19,5 @@ import org.swiften.redux.saga.common.SagaInput
 internal class FromEffect<R>(
   private val stream: Flowable<R>
 ) : SagaEffect<R>() where R : Any {
-  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, this.stream) { EmptyDispatchJob }
+  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, this.stream) { EmptyJob }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
@@ -6,6 +6,7 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Flowable.just
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
 
@@ -16,5 +17,5 @@ import org.swiften.redux.saga.common.SagaInput
  * @param value The [R] value to be emitted.
  */
 internal class JustEffect<R>(private val value: R) : SagaEffect<R>() where R : Any {
-  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, just(this.value)) {}
+  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, just(this.value)) { EmptyDispatchJob }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
@@ -6,7 +6,7 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Flowable.just
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
 
@@ -17,5 +17,5 @@ import org.swiften.redux.saga.common.SagaInput
  * @param value The [R] value to be emitted.
  */
 internal class JustEffect<R>(private val value: R) : SagaEffect<R>() where R : Any {
-  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, just(this.value)) { EmptyDispatchJob }
+  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, just(this.value)) { EmptyJob }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/RxTakeEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/RxTakeEffect.kt
@@ -6,7 +6,7 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.processors.PublishProcessor
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaOutput
@@ -38,7 +38,7 @@ internal abstract class RxTakeEffect<Action, P, R>(
         this@RxTakeEffect.extractor(cls.cast(p))?.also { subject.onNext(it) }
       }
 
-      EmptyDispatchJob
+      EmptyJob
     }
 
     return this.flatten(nested.map { this@RxTakeEffect.creator(it).invoke(p1) })

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/RxTakeEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/RxTakeEffect.kt
@@ -6,6 +6,7 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.processors.PublishProcessor
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaOutput
@@ -36,6 +37,8 @@ internal abstract class RxTakeEffect<Action, P, R>(
       if (cls.isInstance(p)) {
         this@RxTakeEffect.extractor(cls.cast(p))?.also { subject.onNext(it) }
       }
+
+      EmptyDispatchJob
     }
 
     return this.flatten(nested.map { this@RxTakeEffect.creator(it).invoke(p1) })

--- a/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
+++ b/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
@@ -6,15 +6,15 @@
 package org.swiften.redux.saga.rx;
 
 import io.reactivex.Single;
-import kotlin.Unit;
 import kotlinx.coroutines.GlobalScope;
 import org.junit.Test;
+import org.swiften.redux.core.EmptyDispatchJob;
 
 import static org.junit.Assert.assertEquals;
 import static org.swiften.redux.saga.common.CommonEffects.map;
 import static org.swiften.redux.saga.common.CommonEffects.retryMultipleTimes;
-import static org.swiften.redux.saga.rx.SagaEffects.mapSingle;
 import static org.swiften.redux.saga.rx.SagaEffects.just;
+import static org.swiften.redux.saga.rx.SagaEffects.mapSingle;
 
 /**
  * Created by haipham on 2019/01/14
@@ -27,7 +27,7 @@ public final class ReduxSagaTest {
       .transform(map(i -> i * 2))
       .transform(mapSingle(i -> Single.just(i * 3)))
       .transform(retryMultipleTimes(3))
-      .invoke(GlobalScope.INSTANCE, 0, a -> Unit.INSTANCE)
+      .invoke(GlobalScope.INSTANCE, 0, a -> EmptyDispatchJob.INSTANCE)
       .nextValue(1000);
 
     // When && Then

--- a/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
+++ b/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
@@ -8,7 +8,7 @@ package org.swiften.redux.saga.rx;
 import io.reactivex.Single;
 import kotlinx.coroutines.GlobalScope;
 import org.junit.Test;
-import org.swiften.redux.core.EmptyDispatchJob;
+import org.swiften.redux.core.EmptyJob;
 
 import static org.junit.Assert.assertEquals;
 import static org.swiften.redux.saga.common.CommonEffects.map;
@@ -27,7 +27,7 @@ public final class ReduxSagaTest {
       .transform(map(i -> i * 2))
       .transform(mapSingle(i -> Single.just(i * 3)))
       .transform(retryMultipleTimes(3))
-      .invoke(GlobalScope.INSTANCE, 0, a -> EmptyDispatchJob.INSTANCE)
+      .invoke(GlobalScope.INSTANCE, 0, a -> EmptyJob.INSTANCE)
       .nextValue(1000);
 
     // When && Then

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -8,7 +8,7 @@ package org.swiften.redux.saga.common
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxStore
@@ -220,7 +220,7 @@ abstract class SagaEffect<R> : ISagaEffect<R> where R : Any {
    * @param state See [SagaInput.lastState].
    * @return An [ISagaOutput] instance.
    */
-  fun invoke(state: Any) = this.invoke(GlobalScope, state) { EmptyDispatchJob }
+  fun invoke(state: Any) = this.invoke(GlobalScope, state) { EmptyJob }
 
   /**
    * Call [ISagaEffect] with convenience parameters for testing.

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -8,6 +8,7 @@ package org.swiften.redux.saga.common
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxStore
@@ -219,7 +220,7 @@ abstract class SagaEffect<R> : ISagaEffect<R> where R : Any {
    * @param state See [SagaInput.lastState].
    * @return An [ISagaOutput] instance.
    */
-  fun invoke(state: Any) = this.invoke(GlobalScope, state) {}
+  fun invoke(state: Any) = this.invoke(GlobalScope, state) { EmptyDispatchJob }
 
   /**
    * Call [ISagaEffect] with convenience parameters for testing.

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMiddleware.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMiddleware.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.cancel
 import org.swiften.redux.core.DefaultReduxAction
 import org.swiften.redux.core.DispatchMapper
 import org.swiften.redux.core.DispatchWrapper
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IMiddleware
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.MiddlewareInput
@@ -58,7 +58,7 @@ internal class SagaMiddleware(
             scope.coroutineContext.cancel()
           }
 
-          EmptyDispatchJob
+          EmptyJob
         }
       }
     }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMiddleware.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMiddleware.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.cancel
 import org.swiften.redux.core.DefaultReduxAction
 import org.swiften.redux.core.DispatchMapper
 import org.swiften.redux.core.DispatchWrapper
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.core.IMiddleware
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.MiddlewareInput
@@ -56,6 +57,8 @@ internal class SagaMiddleware(
             outputs.forEach { it.dispose() }
             scope.coroutineContext.cancel()
           }
+
+          EmptyDispatchJob
         }
       }
     }

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.swiften.redux.core.DefaultReduxAction
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxActionWithKey
 import java.util.Collections.synchronizedList
@@ -236,7 +237,7 @@ abstract class CommonSagaEffectTest {
     justEffect(0)
       .map { it }
       .putInStore { Action(it) }
-      .invoke(GlobalScope, {}) { dispatched.add(it) }
+      .invoke(GlobalScope, {}) { dispatched.add(it); EmptyDispatchJob }
       .subscribe({})
 
     // When

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.swiften.redux.core.DefaultReduxAction
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxActionWithKey
 import java.util.Collections.synchronizedList
@@ -237,7 +237,7 @@ abstract class CommonSagaEffectTest {
     justEffect(0)
       .map { it }
       .putInStore { Action(it) }
-      .invoke(GlobalScope, {}) { dispatched.add(it); EmptyDispatchJob }
+      .invoke(GlobalScope, {}) { dispatched.add(it); EmptyJob }
       .subscribe({})
 
     // When

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
@@ -12,6 +12,7 @@ import com.nhaarman.mockitokotlin2.verify
 import org.junit.Test
 import org.swiften.redux.core.BaseMiddlewareTest
 import org.swiften.redux.core.DefaultReduxAction
+import org.swiften.redux.core.EmptyDispatchJob
 
 /** Created by haipham on 2019/01/15 */
 class SagaMiddlewareTest : BaseMiddlewareTest() {
@@ -19,7 +20,7 @@ class SagaMiddlewareTest : BaseMiddlewareTest() {
   fun `Redux saga middleware should work correctly`() {
     // Setup
     val outputs = (0 until 100).map { mock<ISagaOutput<Any>> {
-      on { this.onAction } doReturn {}
+      on { this.onAction } doReturn { EmptyDispatchJob }
     } }
 
     val effects = outputs.map<ISagaOutput<Any>, ISagaEffect<Any>> { o -> { o } }

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
@@ -12,7 +12,7 @@ import com.nhaarman.mockitokotlin2.verify
 import org.junit.Test
 import org.swiften.redux.core.BaseMiddlewareTest
 import org.swiften.redux.core.DefaultReduxAction
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 
 /** Created by haipham on 2019/01/15 */
 class SagaMiddlewareTest : BaseMiddlewareTest() {
@@ -20,7 +20,7 @@ class SagaMiddlewareTest : BaseMiddlewareTest() {
   fun `Redux saga middleware should work correctly`() {
     // Setup
     val outputs = (0 until 100).map { mock<ISagaOutput<Any>> {
-      on { this.onAction } doReturn { EmptyDispatchJob }
+      on { this.onAction } doReturn { EmptyJob }
     } }
 
     val effects = outputs.map<ISagaOutput<Any>, ISagaEffect<Any>> { o -> { o } }

--- a/common/common-thunk/src/main/kotlin/org/swiften/redux/thunk/ThunkMiddleware.kt
+++ b/common/common-thunk/src/main/kotlin/org/swiften/redux/thunk/ThunkMiddleware.kt
@@ -8,11 +8,11 @@ package org.swiften.redux.thunk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import org.swiften.redux.core.CoroutineDispatchJob
+import org.swiften.redux.core.CoroutineJob
 import org.swiften.redux.core.DefaultReduxAction
 import org.swiften.redux.core.DispatchMapper
 import org.swiften.redux.core.DispatchWrapper
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IMiddleware
 import org.swiften.redux.core.IReduxAction
@@ -72,13 +72,13 @@ internal class ThunkMiddleware<GExt>(
         wrapper.dispatch(action)
 
         when (action) {
-          is IReduxThunkAction<*, *, *> -> CoroutineDispatchJob(context) {
+          is IReduxThunkAction<*, *, *> -> CoroutineJob(context) {
             val castAction = action as IReduxThunkAction<Any, Any, Any>
             castAction.payload(scope, p1.dispatch, p1.lastState, Unit)
           }
 
-          is DefaultReduxAction.Deinitialize -> { context.cancel(); EmptyDispatchJob }
-          else -> EmptyDispatchJob
+          is DefaultReduxAction.Deinitialize -> { context.cancel(); EmptyJob }
+          else -> EmptyJob
         }
       }
     }

--- a/common/common-thunk/src/test/kotlin/org/swiften/redux/thunk/ThunkMiddlewareTest.kt
+++ b/common/common-thunk/src/test/kotlin/org/swiften/redux/thunk/ThunkMiddlewareTest.kt
@@ -16,6 +16,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.swiften.redux.core.BaseMiddlewareTest
 import org.swiften.redux.core.DefaultReduxAction
+import org.swiften.redux.core.EmptyDispatchJob
 import org.swiften.redux.core.EnhancedReduxStore
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IReduxAction
@@ -48,11 +49,11 @@ class ThunkMiddlewareTest : BaseMiddlewareTest() {
     // Then
     runBlocking {
       assertTrue(thunkAction is IReduxThunkAction<*, *, *>)
-      assertTrue(successCast.payload(GlobalScope, {}, { 0 }, object :
+      assertTrue(successCast.payload(GlobalScope, { EmptyDispatchJob }, { 0 }, object :
         IDependency {}) is Unit)
 
       try {
-        failureCast.payload(GlobalScope, {}, {}, 0)
+        failureCast.payload(GlobalScope, { EmptyDispatchJob }, {}, 0)
         fail("Should not have completed")
       } catch (e: Throwable) { }
     }
@@ -79,7 +80,7 @@ class ThunkMiddlewareTest : BaseMiddlewareTest() {
     }
 
     val dispatched = synchronizedList(arrayListOf<IReduxAction>())
-    val dispatch: IActionDispatcher = { dispatched.add(it) }
+    val dispatch: IActionDispatcher = { dispatched.add(it); EmptyDispatchJob }
     val baseStore = ThreadSafeStore(0) { s, _ -> s }
     val enhancedStore = EnhancedReduxStore(baseStore, dispatch)
     val wrappedDispatch = combineMiddlewares<Int>(createThunkMiddleware(Unit))(enhancedStore)
@@ -102,7 +103,7 @@ class ThunkMiddlewareTest : BaseMiddlewareTest() {
     val dispatched = AtomicInteger(0)
     val job = Job()
     val middleware = createThunkMiddleware(Unit, job)
-    val dispatch: IActionDispatcher = { dispatched.incrementAndGet() }
+    val dispatch: IActionDispatcher = { dispatched.incrementAndGet(); EmptyDispatchJob }
     val dispatchWrapper = this.mockDispatchWrapper(dispatch)
     val input = mockMiddlewareInput(0)
     val wrappedDispatch = middleware(input)(dispatchWrapper).dispatch

--- a/common/common-thunk/src/test/kotlin/org/swiften/redux/thunk/ThunkMiddlewareTest.kt
+++ b/common/common-thunk/src/test/kotlin/org/swiften/redux/thunk/ThunkMiddlewareTest.kt
@@ -16,7 +16,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.swiften.redux.core.BaseMiddlewareTest
 import org.swiften.redux.core.DefaultReduxAction
-import org.swiften.redux.core.EmptyDispatchJob
+import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.EnhancedReduxStore
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IReduxAction
@@ -49,11 +49,11 @@ class ThunkMiddlewareTest : BaseMiddlewareTest() {
     // Then
     runBlocking {
       assertTrue(thunkAction is IReduxThunkAction<*, *, *>)
-      assertTrue(successCast.payload(GlobalScope, { EmptyDispatchJob }, { 0 }, object :
+      assertTrue(successCast.payload(GlobalScope, { EmptyJob }, { 0 }, object :
         IDependency {}) is Unit)
 
       try {
-        failureCast.payload(GlobalScope, { EmptyDispatchJob }, {}, 0)
+        failureCast.payload(GlobalScope, { EmptyJob }, {}, 0)
         fail("Should not have completed")
       } catch (e: Throwable) { }
     }
@@ -80,7 +80,7 @@ class ThunkMiddlewareTest : BaseMiddlewareTest() {
     }
 
     val dispatched = synchronizedList(arrayListOf<IReduxAction>())
-    val dispatch: IActionDispatcher = { dispatched.add(it); EmptyDispatchJob }
+    val dispatch: IActionDispatcher = { dispatched.add(it); EmptyJob }
     val baseStore = ThreadSafeStore(0) { s, _ -> s }
     val enhancedStore = EnhancedReduxStore(baseStore, dispatch)
     val wrappedDispatch = combineMiddlewares<Int>(createThunkMiddleware(Unit))(enhancedStore)
@@ -103,7 +103,7 @@ class ThunkMiddlewareTest : BaseMiddlewareTest() {
     val dispatched = AtomicInteger(0)
     val job = Job()
     val middleware = createThunkMiddleware(Unit, job)
-    val dispatch: IActionDispatcher = { dispatched.incrementAndGet(); EmptyDispatchJob }
+    val dispatch: IActionDispatcher = { dispatched.incrementAndGet(); EmptyJob }
     val dispatchWrapper = this.mockDispatchWrapper(dispatch)
     val input = mockMiddlewareInput(0)
     val wrappedDispatch = middleware(input)(dispatchWrapper).dispatch


### PR DESCRIPTION
Make **IActionDispatcher** return **IAsyncJob** so that it can be waited on to ensure the reducer has finished calculating new state. This allows us access to the latest state if we need, even if **dispatch** is called on different background threads.