### PR TITLE
Sequential saga

### DIFF
--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/AwaitEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/AwaitEffect.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) haipham 2019. All rights reserved.
+ * Any attempt to reproduce this source code in any form shall be met with legal actions.
+ */
+
+package org.swiften.redux.saga.rx
+
+import kotlinx.coroutines.CoroutineScope
+import org.swiften.redux.saga.common.ISagaOutput
+import org.swiften.redux.saga.common.SagaEffect
+import org.swiften.redux.saga.common.SagaInput
+
+/** Created by viethai.pham on 2019/02/17 */
+/** Produces a value using [SagaInput] and [ISagaOutput.awaitFor]. */
+typealias IAwaitCreator<R> = suspend CoroutineScope.(SagaInput) -> R
+
+/**
+ * [SagaEffect] whose [ISagaOutput] is created from [creator], which is a function that creates
+ * [R] using [ISagaOutput.awaitFor]. It is important that the resulting [SagaOutput.stream] emits only
+ * one element.
+ * @param R The result emission type.
+ * @param creator An [IAwaitCreator] instance.
+ */
+internal class AwaitEffect<R>(private val creator: IAwaitCreator<R>) : SagaEffect<R>() where R : Any {
+  override fun invoke(p1: SagaInput): ISagaOutput<R> {
+    return SagaOutput.from(p1.scope) { this@AwaitEffect.creator(this, p1) }
+  }
+}

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/AwaitEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/AwaitEffect.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineScope
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
+import org.swiften.redux.saga.common.SingleSagaEffect
 
 /** Created by viethai.pham on 2019/02/17 */
 /** Produces a value using [SagaInput] and [ISagaOutput.awaitFor]. */
@@ -21,7 +22,7 @@ typealias IAwaitCreator<R> = suspend CoroutineScope.(SagaInput) -> R
  * @param R The result emission type.
  * @param creator An [IAwaitCreator] instance.
  */
-internal class AwaitEffect<R>(private val creator: IAwaitCreator<R>) : SagaEffect<R>() where R : Any {
+internal class AwaitEffect<R>(private val creator: IAwaitCreator<R>) : SingleSagaEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
     return SagaOutput.from(p1.scope) { this@AwaitEffect.creator(this, p1) }
   }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
@@ -9,6 +9,7 @@ import io.reactivex.Flowable.just
 import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
+import org.swiften.redux.saga.common.SingleSagaEffect
 
 /** Created by haipham on 2018/12/24 */
 /**
@@ -16,6 +17,6 @@ import org.swiften.redux.saga.common.SagaInput
  * @param R The result emission type.
  * @param value The [R] value to be emitted.
  */
-internal class JustEffect<R>(private val value: R) : SagaEffect<R>() where R : Any {
+internal class JustEffect<R>(private val value: R) : SingleSagaEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, just(this.value)) { EmptyJob }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaEffects.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaEffects.kt
@@ -14,6 +14,7 @@ import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaEffectTransformer
 import org.swiften.redux.saga.common.ITakeEffectTransformer
 import org.swiften.redux.saga.common.SagaEffect
+import org.swiften.redux.saga.common.SingleSagaEffect
 import org.swiften.redux.saga.common.TakeEffect
 import kotlin.reflect.KClass
 
@@ -24,9 +25,11 @@ object SagaEffects {
    * Create an [AwaitEffect] instance.
    * @param R The result emission type.
    * @param creator See [AwaitEffect.creator].
-   * @return A [SagaEffect] instance.
+   * @return A [SingleSagaEffect] instance.
    */
-  fun <R> await(creator: IAwaitCreator<R>) : SagaEffect<R> where R : Any = AwaitEffect(creator)
+  fun <R> await(creator: IAwaitCreator<R>) : SingleSagaEffect<R> where R : Any {
+    return AwaitEffect(creator)
+  }
 
   /**
    * Create a [CallEffect] instance.
@@ -54,30 +57,30 @@ object SagaEffects {
    * Create a [JustEffect].
    * @param R The result emission type.
    * @param value See [JustEffect.value].
-   * @return A [SagaEffect] instance.
+   * @return A [SingleSagaEffect] instance.
    */
   @JvmStatic
-  fun <R> just(value: R): SagaEffect<R> where R : Any = JustEffect(value)
+  fun <R> just(value: R): SingleSagaEffect<R> where R : Any = JustEffect(value)
 
   /**
    * Call [CommonEffects.putInStore] with [SagaEffects.just].
    * @param P The source emission type.
    * @param value See [JustEffect.value].
    * @param actionCreator See [CommonEffects.putInStore].
-   * @return A [SagaEffect] instance.
+   * @return A [SingleSagaEffect] instance.
    */
   @JvmStatic
-  fun <P> putInStore(value: P, actionCreator: (P) -> IReduxAction): SagaEffect<Any> where P : Any {
+  fun <P> putInStore(value: P, actionCreator: (P) -> IReduxAction): SingleSagaEffect<Any> where P : Any {
     return CommonEffects.putInStore(actionCreator)(this.just(value))
   }
 
   /**
    * Call [putInStore] with [action].
    * @param action An [IReduxAction] instance.
-   * @return A [SagaEffect] instance.
+   * @return A [SingleSagaEffect] instance.
    */
   @JvmStatic
-  fun putInStore(action: IReduxAction): SagaEffect<Any> = this.putInStore(Unit) { action }
+  fun putInStore(action: IReduxAction): SingleSagaEffect<Any> = this.putInStore(Unit) { action }
 
   /**
    * Create a [SelectEffect].
@@ -85,11 +88,11 @@ object SagaEffects {
    * @param R The result emission type.
    * @param cls See [SelectEffect.cls].
    * @param selector See [SelectEffect.selector].
-   * @return A [SagaEffect] instance.
+   * @return A [SingleSagaEffect] instance.
    */
   @JvmStatic
   fun <State, R> selectFromState(cls: Class<State>, selector: (State) -> R):
-    SagaEffect<R> where R : Any {
+    SingleSagaEffect<R> where R : Any {
     return SelectEffect(cls, selector)
   }
 
@@ -99,11 +102,11 @@ object SagaEffects {
    * @param R The result emission type.
    * @param cls See [SelectEffect.cls].
    * @param selector See [SelectEffect.selector].
-   * @return A [SagaEffect] instance.
+   * @return A [SingleSagaEffect] instance.
    */
   @JvmStatic
   fun <State, R> selectFromState(cls: KClass<State>, selector: (State) -> R):
-    SagaEffect<R> where State : Any, R : Any {
+    SingleSagaEffect<R> where State : Any, R : Any {
     return this.selectFromState(cls.java, selector)
   }
 

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaEffects.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaEffects.kt
@@ -21,7 +21,15 @@ import kotlin.reflect.KClass
 /** Top-level namespace for Rx-based [ISagaEffect] */
 object SagaEffects {
   /**
-   * Create a [CallEffect].
+   * Create an [AwaitEffect] instance.
+   * @param R The result emission type.
+   * @param creator See [AwaitEffect.creator].
+   * @return A [SagaEffect] instance.
+   */
+  fun <R> await(creator: IAwaitCreator<R>) : SagaEffect<R> where R : Any = AwaitEffect(creator)
+
+  /**
+   * Create a [CallEffect] instance.
    * @param P The source emission type.
    * @param R The result emission type.
    * @param transformer See [CallEffect.transformer].
@@ -69,9 +77,7 @@ object SagaEffects {
    * @return A [SagaEffect] instance.
    */
   @JvmStatic
-  fun putInStore(action: IReduxAction): SagaEffect<Any> {
-    return this.putInStore(Unit) { action }
-  }
+  fun putInStore(action: IReduxAction): SagaEffect<Any> = this.putInStore(Unit) { action }
 
   /**
    * Create a [SelectEffect].

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaEffects.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaEffects.kt
@@ -13,6 +13,7 @@ import org.swiften.redux.saga.common.CommonEffects
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaEffectTransformer
 import org.swiften.redux.saga.common.ITakeEffectTransformer
+import org.swiften.redux.saga.common.PutEffect
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SingleSagaEffect
 import org.swiften.redux.saga.common.TakeEffect
@@ -67,20 +68,20 @@ object SagaEffects {
    * @param P The source emission type.
    * @param value See [JustEffect.value].
    * @param actionCreator See [CommonEffects.putInStore].
-   * @return A [SingleSagaEffect] instance.
+   * @return A [PutEffect] instance.
    */
   @JvmStatic
-  fun <P> putInStore(value: P, actionCreator: (P) -> IReduxAction): SingleSagaEffect<Any> where P : Any {
+  fun <P> putInStore(value: P, actionCreator: (P) -> IReduxAction): PutEffect<P> where P : Any {
     return CommonEffects.putInStore(actionCreator)(this.just(value))
   }
 
   /**
    * Call [putInStore] with [action].
    * @param action An [IReduxAction] instance.
-   * @return A [SingleSagaEffect] instance.
+   * @return A [PutEffect] instance.
    */
   @JvmStatic
-  fun putInStore(action: IReduxAction): SingleSagaEffect<Any> = this.putInStore(Unit) { action }
+  fun putInStore(action: IReduxAction): PutEffect<Unit> = this.putInStore(Unit) { action }
 
   /**
    * Create a [SelectEffect].

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaEffects.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaEffects.kt
@@ -89,11 +89,10 @@ object SagaEffects {
    * @param R The result emission type.
    * @param cls See [SelectEffect.cls].
    * @param selector See [SelectEffect.selector].
-   * @return A [SingleSagaEffect] instance.
+   * @return A [SelectEffect] instance.
    */
   @JvmStatic
-  fun <State, R> selectFromState(cls: Class<State>, selector: (State) -> R):
-    SingleSagaEffect<R> where R : Any {
+  fun <State, R> selectFromState(cls: Class<State>, selector: (State) -> R): SelectEffect<State, R> where R : Any {
     return SelectEffect(cls, selector)
   }
 
@@ -103,11 +102,10 @@ object SagaEffects {
    * @param R The result emission type.
    * @param cls See [SelectEffect.cls].
    * @param selector See [SelectEffect.selector].
-   * @return A [SingleSagaEffect] instance.
+   * @return A [SelectEffect] instance.
    */
   @JvmStatic
-  fun <State, R> selectFromState(cls: KClass<State>, selector: (State) -> R):
-    SingleSagaEffect<R> where State : Any, R : Any {
+  fun <State, R> selectFromState(cls: KClass<State>, selector: (State) -> R): SelectEffect<State, R> where State : Any, R : Any {
     return this.selectFromState(cls.java, selector)
   }
 

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
@@ -108,11 +108,13 @@ class SagaOutput<T : Any>(
 
   override fun timeout(millis: Long) = this.with(this.stream.timeout(millis, TimeUnit.MILLISECONDS))
 
-  override fun nextValue(timeoutMillis: Long) = try {
-    this.stream
-      .timeout(timeoutMillis, TimeUnit.MILLISECONDS)
-      .blockingFirst()
-  } catch (e: Throwable) { null }
+  override fun await(): T = this.stream.blockingFirst()
+
+  override fun await(defaultValue: T): T = this.stream.blockingFirst(defaultValue)
+
+  override fun await(timeoutMillis: Long): T = this.stream
+    .timeout(timeoutMillis, TimeUnit.MILLISECONDS)
+    .blockingFirst()
 
   override fun subscribe(onValue: (T) -> Unit, onError: (Throwable) -> Unit) {
     this.disposable.add(this.stream.subscribe(onValue, onError))

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
@@ -133,4 +133,11 @@ class SagaOutput<T : Any>(
   override fun subscribe(onValue: (T) -> Unit, onError: (Throwable) -> Unit) {
     this.disposable.add(this.stream.subscribe(onValue, onError))
   }
+
+  /**
+   * Wait forever for the first [T] instance. Beware that if [stream] is empty, this will block
+   * infinitely.
+   * @return A [T] instance.
+   */
+  fun await(): T = this.stream.blockingFirst()
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SelectEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SelectEffect.kt
@@ -8,6 +8,7 @@ package org.swiften.redux.saga.rx
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
+import org.swiften.redux.saga.common.SingleSagaEffect
 
 /** Created by haipham on 2019/01/01 */
 /**
@@ -20,7 +21,7 @@ import org.swiften.redux.saga.common.SagaInput
 internal class SelectEffect<State, R>(
   private val cls: Class<State>,
   private val selector: (State) -> R
-) : SagaEffect<R>() where R : Any {
+) : SingleSagaEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
     val lastState = p1.lastState()
     require(this.cls.isInstance(lastState))

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SelectEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SelectEffect.kt
@@ -18,7 +18,7 @@ import org.swiften.redux.saga.common.SingleSagaEffect
  * @param cls The [Class] to [State].
  * @param selector Function that selects [R] from [State].
  */
-internal class SelectEffect<State, R>(
+class SelectEffect<State, R>(
   private val cls: Class<State>,
   private val selector: (State) -> R
 ) : SingleSagaEffect<R>() where R : Any {
@@ -27,4 +27,12 @@ internal class SelectEffect<State, R>(
     require(this.cls.isInstance(lastState))
     return SagaEffects.just(this.selector(this.cls.cast(lastState))).invoke(p1)
   }
+
+  /**
+   * Since we will always select from an available [State], there will not be a situation whereby
+   * the resulting [ISagaOutput] is empty. We can forgo the default value in this [await].
+   * @param input A [SagaInput] instance.
+   * @return A [R] instance.
+   */
+  fun await(input: SagaInput) = (this.invoke(input) as SagaOutput<R>).await()
 }

--- a/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
+++ b/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
@@ -28,7 +28,7 @@ public final class ReduxSagaTest {
       .transform(mapSingle(i -> Single.just(i * 3)))
       .transform(retryMultipleTimes(3))
       .invoke(GlobalScope.INSTANCE, 0, a -> EmptyJob.INSTANCE)
-      .nextValue(1000);
+      .await(1000);
 
     // When && Then
     assertEquals(value, 6);

--- a/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
+++ b/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
@@ -28,7 +28,7 @@ public final class ReduxSagaTest {
       .transform(mapSingle(i -> Single.just(i * 3)))
       .transform(retryMultipleTimes(3))
       .invoke(GlobalScope.INSTANCE, 0, a -> EmptyJob.INSTANCE)
-      .await(1000);
+      .awaitFor(1000);
 
     // When && Then
     assertEquals(value, 6);

--- a/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
+++ b/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
@@ -289,7 +289,7 @@ class SagaEffectTest : CommonSagaEffectTest() {
 
     val source = await { input ->
       putInStore(ProgressAction(true)).await(input)
-      val value = selectFromState(State::class) { it.value }.await(input, 0)
+      val value = selectFromState(State::class) { it.value }.await(input)
       val newValue = value * 2
       putInStore(ValueAction(newValue)).await(input)
       putInStore(ProgressAction(false)).await(input)

--- a/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
+++ b/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
@@ -131,8 +131,8 @@ class SagaEffectTest : CommonSagaEffectTest() {
     val sourceOutput2 = just(2).selectFromState(State::class) { 4 }.invoke(State())
 
     // When && Then
-    assertEquals(sourceOutput1.nextValue(this.timeout), 3)
-    assertEquals(sourceOutput2.nextValue(this.timeout), 4)
+    assertEquals(sourceOutput1.await(this.timeout), 3)
+    assertEquals(sourceOutput2.await(this.timeout), 4)
   }
 
   @Test

--- a/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
+++ b/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
@@ -288,11 +288,11 @@ class SagaEffectTest : CommonSagaEffectTest() {
     val dispatched = arrayListOf<IReduxAction>()
 
     val source = await { input ->
-      putInStore(ProgressAction(true)).invoke(input).await({})
+      putInStore(ProgressAction(true)).await(input, {})
       val value = selectFromState(State::class) { it.value }.invoke(input).await(0)
       val newValue = value * 2
-      putInStore(ValueAction(newValue)).invoke(input).await({})
-      putInStore(ProgressAction(false)).invoke(input).await({})
+      putInStore(ValueAction(newValue)).await(input, {})
+      putInStore(ProgressAction(false)).await(input, {})
     }
 
     // When
@@ -328,11 +328,11 @@ class SagaEffectTest : CommonSagaEffectTest() {
 
       try {
         val newValue = api(value)
-        putInStore(ValueAction(newValue)).invoke(input).await({})
+        putInStore(ValueAction(newValue)).await(input, {})
       } catch (e: Throwable) {
-        putInStore(ErrorAction(e)).invoke(input).await({})
+        putInStore(ErrorAction(e)).await(input, {})
       } finally {
-        putInStore(ProgressAction(false)).invoke(input).await({})
+        putInStore(ProgressAction(false)).await(input, {})
       }
     }
 

--- a/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
+++ b/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
@@ -288,11 +288,11 @@ class SagaEffectTest : CommonSagaEffectTest() {
     val dispatched = arrayListOf<IReduxAction>()
 
     val source = await { input ->
-      putInStore(ProgressAction(true)).await(input, {})
-      val value = selectFromState(State::class) { it.value }.invoke(input).await(0)
+      putInStore(ProgressAction(true)).await(input)
+      val value = selectFromState(State::class) { it.value }.await(input, 0)
       val newValue = value * 2
-      putInStore(ValueAction(newValue)).await(input, {})
-      putInStore(ProgressAction(false)).await(input, {})
+      putInStore(ValueAction(newValue)).await(input)
+      putInStore(ProgressAction(false)).await(input)
     }
 
     // When
@@ -323,16 +323,16 @@ class SagaEffectTest : CommonSagaEffectTest() {
     val api: suspend (Int) -> Int = { throw error }
 
     val source = await { input ->
-      putInStore(ProgressAction(true)).invoke(input).await({})
+      putInStore(ProgressAction(true)).await(input)
       val value = selectFromState(State::class) { it.value }.filter { false }.invoke(input).await(0)
 
       try {
         val newValue = api(value)
-        putInStore(ValueAction(newValue)).await(input, {})
+        putInStore(ValueAction(newValue)).await(input)
       } catch (e: Throwable) {
-        putInStore(ErrorAction(e)).await(input, {})
+        putInStore(ErrorAction(e)).await(input)
       } finally {
-        putInStore(ProgressAction(false)).await(input, {})
+        putInStore(ProgressAction(false)).await(input)
       }
     }
 

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonEffects.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonEffects.kt
@@ -146,8 +146,7 @@ object CommonEffects {
    * @return An [ISagaEffectTransformer] instance.
    */
   @JvmStatic
-  fun <P> putInStore(actionCreator: (P) -> IReduxAction):
-    (SagaEffect<P>) -> SingleSagaEffect<Any> where P : Any  {
+  fun <P> putInStore(actionCreator: (P) -> IReduxAction): (SagaEffect<P>) -> PutEffect<P> where P : Any  {
     return { PutEffect(it, actionCreator) }
   }
 

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonEffects.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonEffects.kt
@@ -147,7 +147,7 @@ object CommonEffects {
    */
   @JvmStatic
   fun <P> putInStore(actionCreator: (P) -> IReduxAction):
-    ISagaEffectTransformer<P, Any> where P : Any {
+    (SagaEffect<P>) -> SingleSagaEffect<Any> where P : Any  {
     return { PutEffect(it, actionCreator) }
   }
 

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -197,12 +197,6 @@ interface ISagaOutput<T> where T : Any {
   fun timeout(millis: Long): ISagaOutput<T>
 
   /**
-   * Wait for the first [T] that arrives.
-   * @return A [T] instance.
-   */
-  fun await(): T
-
-  /**
    * Wait for the first [T] that arrives, or default to [defaultValue] if the stream is empty.
    * @param defaultValue A [T] instance.
    * @return A [T] instance.
@@ -214,7 +208,7 @@ interface ISagaOutput<T> where T : Any {
    * @param timeoutMillis Timeout time in milliseconds.
    * @return A nullable [T] instance.
    */
-  fun await(timeoutMillis: Long): T
+  fun awaitFor(timeoutMillis: Long): T
 
   /**
    * Subscribe to values with [onValue], and error with [onError].
@@ -245,13 +239,13 @@ abstract class SagaEffect<R> : ISagaEffect<R> where R : Any {
    * @param state See [SagaInput.lastState].
    * @return An [ISagaOutput] instance.
    */
-  fun invoke(state: Any) = this.invoke(SagaInput.withState(state))
+  fun invoke(state: Any): ISagaOutput<R> = this.invoke(SagaInput.withState(state))
 
   /**
    * Call [ISagaEffect] with convenience parameters for testing.
    * @return An [ISagaOutput] instance.
    */
-  fun invoke() = this.invoke(SagaInput.EMPTY)
+  fun invoke(): ISagaOutput<R> = this.invoke(SagaInput.EMPTY)
 
   /**
    * Transform into another [SagaEffect] with [transformer].

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -43,7 +43,19 @@ class SagaInput(
   val scope: CoroutineScope = GlobalScope,
   val lastState: IStateGetter<*>,
   val dispatch: IActionDispatcher
-)
+) {
+  companion object {
+    /** Represents a [SagaInput] that does not have any meaningful functionalities. */
+    val EMPTY = this.withState({})
+
+    /**
+     * Creates a [SagaInput] that simply returns [state] when [SagaInput.lastState] is invoked.
+     * @param state See [SagaInput.lastState].
+     * @return A [SagaInput] instance.
+     */
+    fun withState(state: Any) = SagaInput(GlobalScope, { state }) { EmptyJob }
+  }
+}
 
 /**
  * Stream values for a [ISagaEffect]. This stream has functional operators that can transform
@@ -233,13 +245,13 @@ abstract class SagaEffect<R> : ISagaEffect<R> where R : Any {
    * @param state See [SagaInput.lastState].
    * @return An [ISagaOutput] instance.
    */
-  fun invoke(state: Any) = this.invoke(GlobalScope, state) { EmptyJob }
+  fun invoke(state: Any) = this.invoke(SagaInput.withState(state))
 
   /**
    * Call [ISagaEffect] with convenience parameters for testing.
    * @return An [ISagaOutput] instance.
    */
-  fun invoke() = this.invoke({})
+  fun invoke() = this.invoke(SagaInput.EMPTY)
 
   /**
    * Transform into another [SagaEffect] with [transformer].

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -220,7 +220,7 @@ interface ISagaOutput<T> where T : Any {
 
 /**
  * Abstract class to allow better interfacing with Java.
- * @param R The type of emission value.
+ * @param R The result emission type.
  */
 abstract class SagaEffect<R> : ISagaEffect<R> where R : Any {
   /**
@@ -255,5 +255,32 @@ abstract class SagaEffect<R> : ISagaEffect<R> where R : Any {
    */
   fun <R2> transform(transformer: ISagaEffectTransformer<R, R2>): SagaEffect<R2> where R2 : Any {
     return transformer(this)
+  }
+}
+
+/**
+ * Represents a [SagaEffect] whose [ISagaOutput] only produces a single [R] instance, instead of
+ * a stream.
+ * @param R The result emission type.
+ */
+abstract class SingleSagaEffect<R> : SagaEffect<R>() where R : Any {
+  /**
+   * See [ISagaOutput.await]. We invoke [this] with [input] then call [ISagaOutput.await].
+   * @param input A [SagaInput] instance.
+   * @param defaultValue A [R] instance.
+   * @return A [R] instance.
+   */
+  fun await(input: SagaInput, defaultValue: R): R {
+    return this.invoke(input).await(defaultValue)
+  }
+
+  /**
+   * See [ISagaOutput.await]. We invoke [this] with [input] then call [ISagaOutput.awaitFor].
+   * @param input A [SagaInput] instance.
+   * @param timeoutMillis Timeout time in milliseconds.
+   * @return A [R] instance.
+   */
+  fun awaitFor(input: SagaInput, timeoutMillis: Long): R {
+    return this.invoke(input).awaitFor(timeoutMillis)
   }
 }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -185,11 +185,24 @@ interface ISagaOutput<T> where T : Any {
   fun timeout(millis: Long): ISagaOutput<T>
 
   /**
+   * Wait for the first [T] that arrives.
+   * @return A [T] instance.
+   */
+  fun await(): T
+
+  /**
+   * Wait for the first [T] that arrives, or default to [defaultValue] if the stream is empty.
+   * @param defaultValue A [T] instance.
+   * @return A [T] instance.
+   */
+  fun await(defaultValue: T): T
+
+  /**
    * Get the next [T], but only if it arrives before [timeoutMillis].
    * @param timeoutMillis Timeout time in milliseconds.
-   * @return An [ISagaOutput] instance.
+   * @return A nullable [T] instance.
    */
-  fun nextValue(timeoutMillis: Long): T?
+  fun await(timeoutMillis: Long): T
 
   /**
    * Subscribe to values with [onValue], and error with [onError].

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/PutEffect.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/PutEffect.kt
@@ -16,11 +16,19 @@ import org.swiften.redux.core.IReduxStore
  * @param source The source [ISagaEffect].
  * @param actionCreator Function that creates [IReduxAction] from [P].
  */
-internal class PutEffect<P>(
+class PutEffect<P>(
   private val source: ISagaEffect<P>,
   private val actionCreator: (P) -> IReduxAction
 ) : SingleSagaEffect<Any>() where P : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<Any> {
     return this.source.invoke(p1).map { p1.dispatch(this@PutEffect.actionCreator(it)) as Any }
   }
+
+  /**
+   * Since the result type of [this] is [Any], we can have an [await] method that does not require
+   * default value.
+   * @param input A [SagaInput] instance.
+   * @return [Any] value.
+   */
+  fun await(input: SagaInput): Any = this.await(input, {})
 }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/PutEffect.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/PutEffect.kt
@@ -19,7 +19,7 @@ import org.swiften.redux.core.IReduxStore
 internal class PutEffect<P>(
   private val source: ISagaEffect<P>,
   private val actionCreator: (P) -> IReduxAction
-) : SagaEffect<Any>() where P : Any {
+) : SingleSagaEffect<Any>() where P : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<Any> {
     return this.source.invoke(p1).map { p1.dispatch(this@PutEffect.actionCreator(it)) as Any }
   }

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
@@ -338,6 +338,6 @@ abstract class CommonSagaEffectTest {
       .invoke()
 
     // When && Then
-    assertEquals(finalOutput.nextValue(this.timeout), 100)
+    assertEquals(finalOutput.await(this.timeout), 100)
   }
 }

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
@@ -338,6 +338,6 @@ abstract class CommonSagaEffectTest {
       .invoke()
 
     // When && Then
-    assertEquals(finalOutput.await(this.timeout), 100)
+    assertEquals(finalOutput.awaitFor(this.timeout), 100)
   }
 }

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/Redux.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/Redux.kt
@@ -101,7 +101,7 @@ object Redux {
   object Saga {
     @Suppress("MemberVisibilityCanBePrivate")
     fun searchSaga(api: ISearchAPI<MusicResult?>): SagaEffect<Any> {
-      return takeLatestForKeys(setOf(Action.Search.UPDATE_LIMIT, Action.Search.UPDATE_QUERY)) { a ->
+      return takeLatestForKeys(setOf(Action.Search.UPDATE_LIMIT, Action.Search.UPDATE_QUERY)) { _ ->
         selectFromState(State::class) {
           Option.wrap(it.search.query).zipWithNullable(it.search.limit) { a, b -> a to b.count }
         }


### PR DESCRIPTION
We used to only be able to define saga sequences like this:

```java
selectFromState(State::class) {
  Option.wrap(it.search.query).zipWithNullable(it.search.limit) { a, b -> a to b.count }
}
  .mapIgnoringNull { it.value }
  .thenMightAsWell(putInStore(Action.Search.SetLoading(true)))
  .mapAsync { this.async { Option.wrap(api.searchMusicStore(it.first, it.second)) } }
  .putInStore { Action.UpdateMusicResult(it.value) }
  .thenNoMatterWhat(putInStore(Action.Search.SetLoading(false)))
```

Which is fine for short sequences that comprises functions that take in simple inputs (e.g. pure functions). What if we want to refer to a value that was derived many levels above then? We will need to pass along many values to the target effect.

This PR solves this issue by allowing us to await on effects imperatively. The above code then becomes:

```java
await { input ->
  val searchState = selectFromState(State::class) { it.search }.await(input)
  val query = searchState.query
  val limit = (searchState.limit ?: ResultLimit.FIVE).count
  
  try {
    if (query != null) {
      putInStore(Action.Search.SetLoading(true)).await(input)
      val result = api.searchMusicStore(query, limit)
      putInStore(Action.UpdateMusicResult(result)).await(input)
    }
  } catch (e: Throwable) {
    putInStore(Action.Search.SetError(e)).await(input)
  } finally {
    putInStore(Action.Search.SetLoading(false)).await(input)
  }
}
```

So it looks like synchronous code while actually asynchronous.