### PR TITLE
Split prop container and prop lifecycle owner

### DIFF
--- a/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidLifecycle.kt
+++ b/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidLifecycle.kt
@@ -15,6 +15,7 @@ import org.swiften.redux.ui.IPropInjector
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ReduxProp
+import org.swiften.redux.ui.StaticProp
 
 /** Created by haipham on 2018/12/17 */
 /** Callback for use with [LifecycleObserver]. */
@@ -101,7 +102,8 @@ fun <GState, LState, Owner, OutProp, State, Action> IPropInjector<GState>.inject
   GState : LState,
   LState : Any,
   Owner : LifecycleOwner,
-  Owner : IPropContainer<LState, OutProp, State, Action>,
+  Owner : IPropContainer<State, Action>,
+  Owner : IPropLifecycleOwner<LState, OutProp>,
   State : Any,
   Action : Any {
   var subscription: IReduxSubscription? = null
@@ -115,7 +117,7 @@ fun <GState, LState, Owner, OutProp, State, Action> IPropInjector<GState>.inject
   ReduxLifecycleObserver(lifecycleOwner, object : ILifecycleCallback {
     override fun onSafeForStartingLifecycleAwareTasks() {
       subscription = inject(outProp,
-        object : IPropContainer<LState, OutProp, State, Action> by lifecycleOwner {
+        object : IPropContainer<State, Action>, IPropLifecycleOwner<LState, OutProp> {
           override var reduxProp: ReduxProp<State, Action>
             get() = lifecycleOwner.reduxProp
 
@@ -128,6 +130,14 @@ fun <GState, LState, Owner, OutProp, State, Action> IPropInjector<GState>.inject
               .let { lifecycleOwner.reduxProp = value }
 
           override fun toString() = lifecycleOwner.toString()
+
+          override fun beforePropInjectionStarts(sp: StaticProp<LState, OutProp>) {
+            lifecycleOwner.beforePropInjectionStarts(sp)
+          }
+
+          override fun afterPropInjectionEnds() {
+            lifecycleOwner.afterPropInjectionEnds()
+          }
         }, mapper)
     }
 

--- a/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
+++ b/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
@@ -14,6 +14,7 @@ import org.swiften.redux.core.IDeinitializer
 import org.swiften.redux.core.IReduxSubscription
 import org.swiften.redux.core.IStateGetter
 import org.swiften.redux.core.ReduxSubscription
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
 import org.swiften.redux.ui.IPropLifecycleOwner
@@ -43,7 +44,7 @@ open class BaseLifecycleTest {
 
   class TestLifecycleOwner : LifecycleOwner,
     IPropContainer<Int, Unit>,
-    IPropLifecycleOwner<Int, Unit>,
+    IPropLifecycleOwner<Int, Unit> by NoopPropLifecycleOwner(),
     IPropMapper<Int, Unit, Int, Unit> by TestLifecycleOwner {
     companion object : IPropMapper<Int, Unit, Int, Unit> {
       override fun mapState(state: Int, outProp: Unit) = state

--- a/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
+++ b/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
@@ -16,6 +16,7 @@ import org.swiften.redux.core.IStateGetter
 import org.swiften.redux.core.ReduxSubscription
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.ReduxProp
@@ -41,7 +42,8 @@ open class BaseLifecycleTest {
   }
 
   class TestLifecycleOwner : LifecycleOwner,
-    IPropContainer<Int, Unit, Int, Unit>,
+    IPropContainer<Int, Unit>,
+    IPropLifecycleOwner<Int, Unit>,
     IPropMapper<Int, Unit, Int, Unit> by TestLifecycleOwner {
     companion object : IPropMapper<Int, Unit, Int, Unit> {
       override fun mapState(state: Int, outProp: Unit) = state
@@ -58,11 +60,16 @@ open class BaseLifecycleTest {
     val injectionCount get() = this.subscriptions.size
 
     @Suppress("UNCHECKED_CAST")
-    override fun <LState, OutProp, State, Action> inject(
+    override fun <LState, OutProp, View, State, Action> inject(
       outProp: OutProp,
-      view: IPropContainer<LState, OutProp, State, Action>,
+      view: View,
       mapper: IPropMapper<LState, OutProp, State, Action>
-    ): IReduxSubscription where LState : Any, State : Any, Action : Any {
+    ): IReduxSubscription where
+      LState : Any,
+      View : IPropContainer<State, Action>,
+      View : IPropLifecycleOwner<LState, OutProp>,
+      State : Any,
+      Action : Any {
       val lastState = this.lastState()
       val subscription = ReduxSubscription("$view") { view.afterPropInjectionEnds() }
       val state = mapper.mapState(lastState as LState, outProp)

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.swiften.redux.core.CompositeReduxSubscription
 import org.swiften.redux.core.ReduxSubscription
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
 import org.swiften.redux.ui.IPropLifecycleOwner
@@ -47,8 +48,8 @@ abstract class ReduxListAdapter<GState, LState, OutProp, VH, VHState, VHAction>(
   private val adapter: RecyclerView.Adapter<VH>,
   diffCallback: DiffUtil.ItemCallback<VHState>
 ) : ListAdapter<VHState, VH>(diffCallback),
-  IPropContainer<List<VHState>, VHAction>,
-  IPropLifecycleOwner<LState, OutProp> where
+  IPropLifecycleOwner<LState, OutProp> by NoopPropLifecycleOwner(),
+  IPropContainer<List<VHState>, VHAction> where
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
@@ -13,6 +13,7 @@ import org.swiften.redux.core.CompositeReduxSubscription
 import org.swiften.redux.core.ReduxSubscription
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.ReduxProp
@@ -46,7 +47,8 @@ abstract class ReduxListAdapter<GState, LState, OutProp, VH, VHState, VHAction>(
   private val adapter: RecyclerView.Adapter<VH>,
   diffCallback: DiffUtil.ItemCallback<VHState>
 ) : ListAdapter<VHState, VH>(diffCallback),
-  IPropContainer<LState, OutProp, List<VHState>, VHAction> where
+  IPropContainer<List<VHState>, VHAction>,
+  IPropLifecycleOwner<LState, OutProp> where
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
@@ -158,7 +160,8 @@ fun <GState, LState, OutProp, VH, VHState, VHAction> IPropInjector<GState>.injec
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, OutProp, VHState, VHAction>,
+  VH : IPropContainer<VHState, VHAction>,
+  VH : IPropLifecycleOwner<LState, OutProp>,
   VHState : Any,
   VHAction : Any {
   val listAdapter = object : ReduxListAdapter<GState, LState, OutProp, VH, VHState, VHAction>(adapter, diffCallback) {

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/LifecycleAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/LifecycleAdapter.kt
@@ -13,6 +13,7 @@ import org.swiften.redux.android.ui.lifecycle.ILifecycleCallback
 import org.swiften.redux.android.ui.lifecycle.ReduxLifecycleObserver
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper
 import org.swiften.redux.ui.ReduxProp
@@ -46,7 +47,8 @@ fun <GState, LState, OutProp, VH, VHState, VHAction> IPropInjector<GState>.injec
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, PositionProp<OutProp>, VHState, VHAction>,
+  VH : IPropContainer<VHState, VHAction>,
+  VH : IPropLifecycleOwner<LState, PositionProp<OutProp>>,
   VHState : Any,
   VHAction : Any {
   val wrappedAdapter = this.injectRecyclerAdapter(outProp, adapter, adapterMapper, vhMapper)
@@ -85,7 +87,8 @@ fun <GState, LState, OutProp, VH, VHState, VHAction> IPropInjector<GState>.injec
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, OutProp, VHState, VHAction>,
+  VH : IPropContainer<VHState, VHAction>,
+  VH : IPropLifecycleOwner<LState, OutProp>,
   VHState : Any,
   VHAction : Any {
   val wrappedAdapter = this.injectDiffedAdapter(outProp, adapter, adapterMapper, diffCallback)
@@ -128,7 +131,8 @@ fun <GState, LState, OutProp, VH, VHState, VHAction> IPropInjector<GState>.injec
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, OutProp, VHState, VHAction>,
+  VH : IPropContainer<VHState, VHAction>,
+  VH : IPropLifecycleOwner<LState, OutProp>,
   VHState : Any,
   VHAction : Any {
   return this.injectDiffedAdapter(outProp, lifecycleOwner, adapter, adapterMapper,

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.RecyclerView
 import org.swiften.redux.core.CompositeReduxSubscription
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper
 import org.swiften.redux.ui.ReduxProp
@@ -54,7 +55,8 @@ abstract class DelegateRecyclerAdapter<GState, LState, OutProp, VH, VHState, VHA
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, PositionProp<OutProp>, VHState, VHAction>,
+  VH : IPropContainer<VHState, VHAction>,
+  VH : IPropLifecycleOwner<LState, PositionProp<OutProp>>,
   VHState : Any,
   VHAction : Any {
   protected val composite = CompositeReduxSubscription("${this.javaClass}${Date().time}")
@@ -145,7 +147,8 @@ fun <GState, LState, OutProp, VH, VHState, VHAction> IPropInjector<GState>.injec
   GState : LState,
   LState : Any,
   VH : RecyclerView.ViewHolder,
-  VH : IPropContainer<LState, PositionProp<OutProp>, VHState, VHAction>,
+  VH : IPropContainer<VHState, VHAction>,
+  VH : IPropLifecycleOwner<LState, PositionProp<OutProp>>,
   VHState : Any,
   VHAction : Any {
   return object : DelegateRecyclerAdapter<GState, LState, OutProp, VH, VHState, VHAction>(adapter) {

--- a/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapterTest.kt
+++ b/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapterTest.kt
@@ -21,6 +21,7 @@ import org.robolectric.annotation.Config
 import org.swiften.redux.android.ui.lifecycle.BaseLifecycleTest
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
@@ -31,7 +32,8 @@ import java.util.concurrent.atomic.AtomicInteger
 @RunWith(RobolectricTestRunner::class)
 class DiffedAdapterTest : BaseLifecycleTest() {
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
-    IPropContainer<Int, Unit, Int, ViewHolder.A> {
+    IPropContainer<Int, ViewHolder.A>,
+    IPropLifecycleOwner<Int, Unit> {
     class A
 
     val afterInjection = AtomicInteger()

--- a/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
+++ b/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
@@ -24,6 +24,7 @@ import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -33,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class RecycleAdapterTest : BaseLifecycleTest() {
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
     IPropContainer<Int, Unit>,
-    IPropLifecycleOwner<Int, PositionProp<Unit>> {
+    IPropLifecycleOwner<Int, PositionProp<Unit>> by NoopPropLifecycleOwner() {
     companion object : IPropMapper<Int, PositionProp<Unit>, Int, Unit> {
       override fun mapState(state: Int, outProp: PositionProp<Unit>) = state
       override fun mapAction(dispatch: IActionDispatcher, outProp: PositionProp<Unit>) = Unit

--- a/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
+++ b/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
@@ -21,6 +21,7 @@ import org.robolectric.annotation.Config
 import org.swiften.redux.android.ui.lifecycle.BaseLifecycleTest
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper
 import org.swiften.redux.ui.ObservableReduxProp
@@ -31,7 +32,8 @@ import java.util.concurrent.atomic.AtomicInteger
 @RunWith(RobolectricTestRunner::class)
 class RecycleAdapterTest : BaseLifecycleTest() {
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
-    IPropContainer<Int, PositionProp<Unit>, Int, Unit> {
+    IPropContainer<Int, Unit>,
+    IPropLifecycleOwner<Int, PositionProp<Unit>> {
     companion object : IPropMapper<Int, PositionProp<Unit>, Int, Unit> {
       override fun mapState(state: Int, outProp: PositionProp<Unit>) = state
       override fun mapAction(dispatch: IActionDispatcher, outProp: PositionProp<Unit>) = Unit

--- a/android/android-ui/src/main/java/org/swiften/redux/android/ui/AndroidPropInjector.kt
+++ b/android/android-ui/src/main/java/org/swiften/redux/android/ui/AndroidPropInjector.kt
@@ -9,6 +9,7 @@ import org.swiften.redux.android.util.AndroidUtil
 import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.core.IReduxSubscription
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.PropInjector
 import org.swiften.redux.ui.ReduxProp
@@ -26,12 +27,17 @@ class AndroidPropInjector<GState>(
   store: IReduxStore<GState>,
   private val runner: AndroidUtil.IMainThreadRunner = AndroidUtil.MainThreadRunner
 ) : PropInjector<GState>(store) where GState : Any {
-  override fun <LState, OutProp, State, Action> inject(
+  override fun <LState, OutProp, View, State, Action> inject(
     outProp: OutProp,
-    view: IPropContainer<LState, OutProp, State, Action>,
+    view: View,
     mapper: IPropMapper<LState, OutProp, State, Action>
-  ): IReduxSubscription where LState : Any, State : Any, Action : Any {
-    return super.inject(outProp, object : IPropContainer<LState, OutProp, State, Action> {
+  ): IReduxSubscription where
+    LState : Any,
+    View : IPropContainer<State, Action>,
+    View : IPropLifecycleOwner<LState, OutProp>,
+    State : Any,
+    Action : Any {
+    return super.inject(outProp, object : IPropContainer<State, Action>, IPropLifecycleOwner<LState, OutProp> {
       override var reduxProp: ReduxProp<State, Action>
         get() = view.reduxProp
         set(value) { this@AndroidPropInjector.runner { view.reduxProp = value } }

--- a/android/android-ui/src/test/java/org/swiften/redux/android/ui/AndroidInjectorTest.kt
+++ b/android/android-ui/src/test/java/org/swiften/redux/android/ui/AndroidInjectorTest.kt
@@ -17,6 +17,7 @@ import org.swiften.redux.android.util.AndroidUtil
 import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.PropInjectorTest
 import org.swiften.redux.ui.ReduxProp
 import org.swiften.redux.ui.StaticProp
@@ -44,7 +45,7 @@ class AndroidInjectorTest : PropInjectorTest() {
     this.runner = Runner()
   }
 
-  internal class AndroidView : IPropContainer<S, Unit, S, A> {
+  internal class AndroidView : IPropContainer<S, A>, IPropLifecycleOwner<S, Unit> {
     /**
      * Make sue [VetoableObservableProp.equalChecker] always returns false to avoid comparison
      * because [AndroidUtil.IMainThreadRunner.invoke] is performed before the prop comparison

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
@@ -25,17 +25,26 @@ import kotlin.concurrent.write
  */
 interface IPropLifecycleOwner<LState, OutProp> where LState : Any {
   /**
-   * This is called before [IPropInjector.inject] is called. Override the default implementation to
-   * catch this event.
+   * This is called before [IPropInjector.inject] is called.
    * @param sp A [StaticProp] instance.
    */
-  fun beforePropInjectionStarts(sp: StaticProp<LState, OutProp>) {}
+  fun beforePropInjectionStarts(sp: StaticProp<LState, OutProp>)
 
   /**
-   * This is called after [IReduxSubscription.unsubscribe] is called. Override the default
-   * implementation to catch this event.
+   * This is called after [IReduxSubscription.unsubscribe] is called.
    */
-  fun afterPropInjectionEnds() {}
+  fun afterPropInjectionEnds()
+}
+
+/**
+ * Use this class as a delegate for [IPropLifecycleOwner] if the target does not want to implement
+ * lifecycles.
+ * @param LState The local state type that the global state must extend from.
+ * @param OutProp Property as defined by a view's parent.
+ */
+class NoopPropLifecycleOwner<LState, OutProp> : IPropLifecycleOwner<LState, OutProp> where LState : Any {
+  override fun beforePropInjectionStarts(sp: StaticProp<LState, OutProp>) {}
+  override fun afterPropInjectionEnds() {}
 }
 
 /**

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/ObservableProp.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/ObservableProp.kt
@@ -11,7 +11,7 @@ import kotlin.concurrent.write
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
-/** Created by haipham on 2019/19/01 */
+/** Created by haipham on 2019/01/19 */
 /**
  * Note that [notifier] passes along both the previous and upcoming [T] values
  * @param T The property type to be observed.
@@ -36,7 +36,7 @@ open class VetoableObservableProp<T>(
 }
 
 /**
- * Use this to avoid lateinit modifiers for [ReduxProp]
+ * Use this to avoid lateinit modifiers for [ReduxProp].
  * @param State See [ReduxProp.state].
  * @param Action See [ReduxProp.action].
  * @param notifier See [VetoableObservableProp.notifier].

--- a/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
+++ b/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
@@ -43,7 +43,7 @@ open class PropInjectorTest {
     }
   }
 
-  internal class View : IPropContainer<S, Unit, S, A> {
+  internal class View : IPropContainer<S, A>, IPropLifecycleOwner<S, Unit> {
     override var reduxProp by ObservableReduxProp<S, A> { prev, next ->
       this.propCallback?.invoke(prev, next)
       this.propInjectionCount.incrementAndGet()

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/DetailFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/DetailFragment.kt
@@ -16,12 +16,13 @@ import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 
 /** Created by haipham on 27/1/19 */
 class DetailFragment : Fragment(),
   IPropContainer<DetailFragment.S, Unit>,
-  IPropLifecycleOwner<DetailFragment.ILocalState, Unit> {
+  IPropLifecycleOwner<DetailFragment.ILocalState, Unit> by NoopPropLifecycleOwner() {
   companion object : IPropMapper<ILocalState, Unit, DetailFragment.S, Unit> {
     override fun mapState(state: ILocalState, outProp: Unit): S {
       return S(state.selectedTrack?.let { i -> state.musicResult?.results?.elementAtOrNull(i) })

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/DetailFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/DetailFragment.kt
@@ -14,16 +14,14 @@ import kotlinx.android.synthetic.main.detail_fragment.artistName
 import kotlinx.android.synthetic.main.detail_fragment.trackName
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 
 /** Created by haipham on 27/1/19 */
-class DetailFragment : Fragment(), IPropContainer<
-  DetailFragment.ILocalState,
-  Unit,
-  DetailFragment.S,
-  Unit
-  > {
+class DetailFragment : Fragment(),
+  IPropContainer<DetailFragment.S, Unit>,
+  IPropLifecycleOwner<DetailFragment.ILocalState, Unit> {
   companion object : IPropMapper<ILocalState, Unit, DetailFragment.S, Unit> {
     override fun mapState(state: ILocalState, outProp: Unit): S {
       return S(state.selectedTrack?.let { i -> state.musicResult?.results?.elementAtOrNull(i) })

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
@@ -17,6 +17,7 @@ import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
 import java.io.Serializable
@@ -24,7 +25,7 @@ import java.io.Serializable
 /** Created by haipham on 27/1/19 */
 class MainFragment : Fragment(),
   IPropContainer<MainFragment.S, MainFragment.A>,
-  IPropLifecycleOwner<MainFragment.ILocalState, Unit> {
+  IPropLifecycleOwner<MainFragment.ILocalState, Unit> by NoopPropLifecycleOwner() {
   companion object : IPropMapper<ILocalState, Unit, S, A> {
     override fun mapAction(dispatch: IActionDispatcher, outProp: Unit): A {
       return A { dispatch(Redux.Action.Main.UpdateSelectedPage(it)) }

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
@@ -15,18 +15,16 @@ import androidx.viewpager.widget.ViewPager
 import kotlinx.android.synthetic.main.main_fragment.view_pager
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
 import java.io.Serializable
 
 /** Created by haipham on 27/1/19 */
-class MainFragment : Fragment(), IPropContainer<
-  MainFragment.ILocalState,
-  Unit,
-  MainFragment.S,
-  MainFragment.A
-  > {
+class MainFragment : Fragment(),
+  IPropContainer<MainFragment.S, MainFragment.A>,
+  IPropLifecycleOwner<MainFragment.ILocalState, Unit> {
   companion object : IPropMapper<ILocalState, Unit, S, A> {
     override fun mapAction(dispatch: IActionDispatcher, outProp: Unit): A {
       return A { dispatch(Redux.Action.Main.UpdateSelectedPage(it)) }

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/SearchFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/SearchFragment.kt
@@ -26,6 +26,7 @@ import org.swiften.redux.android.ui.recyclerview.ReduxRecyclerViewAdapter
 import org.swiften.redux.android.ui.recyclerview.injectDiffedAdapter
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
@@ -56,7 +57,8 @@ class SearchAdapter : ReduxRecyclerViewAdapter<SearchAdapter.ViewHolder>() {
   class A(val selectTrack: (Int?) -> Unit)
 
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
-    IPropContainer<ILocalState, Unit, S, A> {
+    IPropContainer<S, A>,
+    IPropLifecycleOwner<ILocalState, Unit> {
     override var reduxProp by ObservableReduxProp<S, A> { _, next ->
       next.state?.track?.also {
         this.trackName.text = it.trackName
@@ -81,12 +83,9 @@ class SearchAdapter : ReduxRecyclerViewAdapter<SearchAdapter.ViewHolder>() {
   }
 }
 
-class SearchFragment : Fragment(), IPropContainer<
-  SearchFragment.ILocalState,
-  Unit,
-  SearchFragment.S,
-  SearchFragment.A
-  > {
+class SearchFragment : Fragment(),
+  IPropContainer<SearchFragment.S, SearchFragment.A>,
+  IPropLifecycleOwner<SearchFragment.ILocalState, Unit> {
   companion object : IPropMapper<ILocalState, Unit, S, A> {
     override fun mapState(state: ILocalState, outProp: Unit) = state.search
 

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/SearchFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/SearchFragment.kt
@@ -28,6 +28,7 @@ import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
 
@@ -58,7 +59,7 @@ class SearchAdapter : ReduxRecyclerViewAdapter<SearchAdapter.ViewHolder>() {
 
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
     IPropContainer<S, A>,
-    IPropLifecycleOwner<ILocalState, Unit> {
+    IPropLifecycleOwner<ILocalState, Unit> by NoopPropLifecycleOwner() {
     override var reduxProp by ObservableReduxProp<S, A> { _, next ->
       next.state?.track?.also {
         this.trackName.text = it.trackName
@@ -85,7 +86,7 @@ class SearchAdapter : ReduxRecyclerViewAdapter<SearchAdapter.ViewHolder>() {
 
 class SearchFragment : Fragment(),
   IPropContainer<SearchFragment.S, SearchFragment.A>,
-  IPropLifecycleOwner<SearchFragment.ILocalState, Unit> {
+  IPropLifecycleOwner<SearchFragment.ILocalState, Unit> by NoopPropLifecycleOwner() {
   companion object : IPropMapper<ILocalState, Unit, S, A> {
     override fun mapState(state: ILocalState, outProp: Unit) = state.search
 

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -30,12 +30,13 @@ import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
 
 class GardenFragment : Fragment(),
   IPropContainer<GardenFragment.S, Unit>,
-  IPropLifecycleOwner<Redux.State, GardenFragment.IDependency> {
+  IPropLifecycleOwner<Redux.State, GardenFragment.IDependency> by NoopPropLifecycleOwner() {
   interface IDependency : GardenPlantingAdapter.IDependency
 
   data class S(val gardenPlantingCount: Int)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -28,12 +28,14 @@ import kotlinx.android.synthetic.main.fragment_garden.garden_list
 import org.swiften.redux.android.ui.recyclerview.injectRecyclerAdapter
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
 
 class GardenFragment : Fragment(),
-  IPropContainer<Redux.State, GardenFragment.IDependency, GardenFragment.S, Unit> {
+  IPropContainer<GardenFragment.S, Unit>,
+  IPropLifecycleOwner<Redux.State, GardenFragment.IDependency> {
   interface IDependency : GardenPlantingAdapter.IDependency
 
   data class S(val gardenPlantingCount: Int)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -48,6 +48,7 @@ import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
 
@@ -57,7 +58,7 @@ import org.swiften.redux.ui.StaticProp
 @SuppressLint("RestrictedApi")
 class PlantDetailFragment : Fragment(),
   IPropContainer<PlantDetailFragment.S, PlantDetailFragment.A>,
-  IPropLifecycleOwner<Redux.State, PlantDetailFragment.IDependency> {
+  IPropLifecycleOwner<Redux.State, PlantDetailFragment.IDependency> by NoopPropLifecycleOwner() {
   interface IDependency : IPicassoProvider
 
   data class S(val plant: Plant? = null, val isPlanted: Boolean? = null)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -46,6 +46,7 @@ import kotlinx.android.synthetic.main.fragment_plant_detail.plant_watering
 import kotlinx.android.synthetic.main.fragment_plant_detail.toolbar_layout
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
@@ -55,7 +56,8 @@ import org.swiften.redux.ui.StaticProp
  */
 @SuppressLint("RestrictedApi")
 class PlantDetailFragment : Fragment(),
-  IPropContainer<Redux.State, PlantDetailFragment.IDependency, PlantDetailFragment.S, PlantDetailFragment.A> {
+  IPropContainer<PlantDetailFragment.S, PlantDetailFragment.A>,
+  IPropLifecycleOwner<Redux.State, PlantDetailFragment.IDependency> {
   interface IDependency : IPicassoProvider
 
   data class S(val plant: Plant? = null, val isPlanted: Boolean? = null)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -30,12 +30,14 @@ import kotlinx.android.synthetic.main.fragment_plant_list.plant_list
 import org.swiften.redux.android.ui.recyclerview.injectDiffedAdapter
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
 
 class PlantListFragment : Fragment(),
-  IPropContainer<Redux.State, PlantListFragment.IDependency, PlantListFragment.S, PlantListFragment.A> {
+  IPropContainer<PlantListFragment.S, PlantListFragment.A>,
+  IPropLifecycleOwner<Redux.State, PlantListFragment.IDependency> {
   interface IDependency : PlantAdapter.IDependency
 
   data class S(val plantCount: Int)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -32,12 +32,13 @@ import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
 
 class PlantListFragment : Fragment(),
   IPropContainer<PlantListFragment.S, PlantListFragment.A>,
-  IPropLifecycleOwner<Redux.State, PlantListFragment.IDependency> {
+  IPropLifecycleOwner<Redux.State, PlantListFragment.IDependency> by NoopPropLifecycleOwner() {
   interface IDependency : PlantAdapter.IDependency
 
   data class S(val plantCount: Int)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
@@ -32,6 +32,7 @@ import org.swiften.redux.android.ui.recyclerview.PositionProp
 import org.swiften.redux.android.ui.recyclerview.ReduxRecyclerViewAdapter
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper
 import org.swiften.redux.ui.ObservableReduxProp
@@ -55,7 +56,8 @@ class GardenPlantingAdapter : ReduxRecyclerViewAdapter<GardenPlantingAdapter.Vie
   }
 
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
-    IPropContainer<Redux.State, PositionProp<IDependency>, ViewHolder.S, ViewHolder.A> {
+    IPropContainer<ViewHolder.S, ViewHolder.A>,
+    IPropLifecycleOwner<Redux.State, PositionProp<IDependency>> {
     data class S(val plantings: PlantAndGardenPlantings?)
     class A(override val picasso: Picasso, val goToPlantDetail: () -> Unit) : IPicassoProvider
 

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
@@ -35,6 +35,7 @@ import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.StaticProp
 import java.text.SimpleDateFormat
@@ -57,7 +58,7 @@ class GardenPlantingAdapter : ReduxRecyclerViewAdapter<GardenPlantingAdapter.Vie
 
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
     IPropContainer<ViewHolder.S, ViewHolder.A>,
-    IPropLifecycleOwner<Redux.State, PositionProp<IDependency>> {
+    IPropLifecycleOwner<Redux.State, PositionProp<IDependency>> by NoopPropLifecycleOwner() {
     data class S(val plantings: PlantAndGardenPlantings?)
     class A(override val picasso: Picasso, val goToPlantDetail: () -> Unit) : IPicassoProvider
 

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
@@ -33,6 +33,7 @@ import org.swiften.redux.android.ui.recyclerview.IDiffItemCallback
 import org.swiften.redux.android.ui.recyclerview.ReduxRecyclerViewAdapter
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
 
@@ -70,7 +71,8 @@ class PlantAdapter : ReduxRecyclerViewAdapter<PlantAdapter.ViewHolder>() {
   }
 
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
-    IPropContainer<Redux.State, IDependency, Plant, ViewHolder.A> {
+    IPropContainer<Plant, ViewHolder.A>,
+    IPropLifecycleOwner<Redux.State, IDependency> {
     class A(override val picasso: Picasso, val goToPlantDetail: (Int) -> Unit) : IPicassoProvider
 
     private val image: ImageView = itemView.findViewById(R.id.plant_item_image)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
@@ -35,6 +35,7 @@ import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 
 /**
@@ -72,7 +73,7 @@ class PlantAdapter : ReduxRecyclerViewAdapter<PlantAdapter.ViewHolder>() {
 
   class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
     IPropContainer<Plant, ViewHolder.A>,
-    IPropLifecycleOwner<Redux.State, IDependency> {
+    IPropLifecycleOwner<Redux.State, IDependency> by NoopPropLifecycleOwner() {
     class A(override val picasso: Picasso, val goToPlantDetail: (Int) -> Unit) : IPicassoProvider
 
     private val image: ImageView = itemView.findViewById(R.id.plant_item_image)


### PR DESCRIPTION
Split **IPropLifecycleOwner** from **IPropContainer** in order to reduce generic requirement for **IPropContainer**, so code that looks like:

```kotlin
class Fragment1 : Fragment(), 
  IPropContainer<Fragment1.ILocalState, Fragment1.IDependency, Fragment1.S, Fragment1.A> {
  ...
}
```

Now becomes:

```kotlin
class Fragment1 : Fragment(), 
  IPropContainer<Fragment1.S, Fragment1.A>,
  IPropLifecycleOwner<Fragment1.ILocalState, Fragment1.IDependency> {
  ...
}
```

This looks much cleaner and clearer in purpose.