### PR TITLE
Typed async job

### DIFF
--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncJob.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncJob.kt
@@ -7,8 +7,9 @@ package org.swiften.redux.core
 
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
-import java.util.concurrent.CountDownLatch
+import kotlinx.coroutines.withTimeout
 
 /** Created by haipham on 2019/02/16 */
 /**
@@ -21,11 +22,28 @@ interface IAsyncJob<T> where T : Any {
    * @return A [T] instance.
    */
   fun await(): T
+
+  /**
+   * Same as [await], but return a default [T] instance if [await] errors out or is empty.
+   * @param defaultValue A [T] instance.
+   * @return A [T] instance.
+   */
+  fun await(defaultValue: T): T
+
+  /**
+   * Same as [await], but only up till [timeoutMillis]. Throw a [Throwable] otherwise.
+   * @param timeoutMillis The timeout time in milliseconds.
+   * @return A [T] instance.
+   */
+  @Throws(Exception::class)
+  fun awaitFor(timeoutMillis: Long): T
 }
 
 /** Represents an empty [IAsyncJob] that does not do anything. */
 object EmptyJob : IAsyncJob<Unit> {
   override fun await() = Unit
+  override fun await(defaultValue: Unit) = this.await()
+  override fun awaitFor(timeoutMillis: Long) = this.await()
 }
 
 /**
@@ -35,16 +53,24 @@ object EmptyJob : IAsyncJob<Unit> {
  */
 class JustJob<T>(private val value: T) : IAsyncJob<T> where T : Any {
   override fun await() = this.value
+  override fun await(defaultValue: T) = this.value
+  override fun awaitFor(timeoutMillis: Long) = this.value
 }
 
 /**
  * Represents an [IAsyncJob] that handles [Job]. It waits for [job] to resolve synchronously with
- * a [CountDownLatch].
+ * [runBlocking]. If [awaitFor] is used, make sure [job] is cooperative with cancellation.
  * @param T The return type of [await].
  * @param job The [Job] to be resolved.
  */
 class CoroutineJob<T>(private val job: Deferred<T>) : IAsyncJob<T> where T : Any {
-  override fun await(): T {
-    return runBlocking { this@CoroutineJob.job.await() }
+  override fun await() = runBlocking { this@CoroutineJob.job.await() }
+  override fun await(defaultValue: T) = try { this.await() } catch (e: Throwable) { defaultValue }
+
+  @Throws(TimeoutCancellationException::class)
+  override fun awaitFor(timeoutMillis: Long): T {
+    return runBlocking {
+      withTimeout(timeoutMillis) { this@CoroutineJob.await() }
+    }
   }
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncJob.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncJob.kt
@@ -11,29 +11,40 @@ import kotlinx.coroutines.runBlocking
 import java.util.concurrent.CountDownLatch
 
 /** Created by haipham on 2019/02/16 */
-/** Represents a job that does some asynchronous work and can be resolved synchronously. */
-interface IAsyncJob {
-  /** Wait until some asynchronous action finishes. */
-  fun await(): Any
+/**
+ * Represents a job that does some asynchronous work and can be resolved synchronously.
+ * @param T The return type of [await].
+ */
+interface IAsyncJob<T> where T : Any {
+  /**
+   * Wait until some asynchronous action finishes.
+   * @return A [T] instance.
+   */
+  fun await(): T
 }
 
 /** Represents an empty [IAsyncJob] that does not do anything. */
-object EmptyJob : IAsyncJob {
+object EmptyJob : IAsyncJob<Unit> {
   override fun await() = Unit
 }
 
-/** Represents an [IAsyncJob] that returns some [value] on [await]. */
-class JustJob(private val value: Any) : IAsyncJob {
+/**
+ * Represents an [IAsyncJob] that returns some [value] on [await].
+ * @param T The return type of [await].
+ * @param value A [T] instance.
+ */
+class JustJob<T>(private val value: T) : IAsyncJob<T> where T : Any {
   override fun await() = this.value
 }
 
 /**
  * Represents an [IAsyncJob] that handles [Job]. It waits for [job] to resolve synchronously with
  * a [CountDownLatch].
+ * @param T The return type of [await].
  * @param job The [Job] to be resolved.
  */
-class CoroutineJob(private val job: Deferred<Any>) : IAsyncJob {
-  override fun await(): Any {
+class CoroutineJob<T>(private val job: Deferred<T>) : IAsyncJob<T> where T : Any {
+  override fun await(): T {
     return runBlocking { this@CoroutineJob.job.await() }
   }
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
@@ -7,7 +7,7 @@ package org.swiften.redux.core
 
 /** Created by haipham on 2018/03/31 */
 /** Represents an [IReduxAction] dispatcher. */
-typealias IActionDispatcher = (IReduxAction) -> IAsyncJob
+typealias IActionDispatcher = (IReduxAction) -> IAsyncJob<*>
 
 /**
  * Represents a Redux reducer that reduce a [IReduxAction] onto a previous state to produce a new

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeDispatcher.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeDispatcher.kt
@@ -19,7 +19,7 @@ class ThreadSafeDispatcher(
   private val lock: ReentrantLock = ReentrantLock(),
   private val dispatch: IActionDispatcher
 ) : IActionDispatcher {
-  override fun invoke(p1: IReduxAction): IAsyncJob {
+  override fun invoke(p1: IReduxAction): IAsyncJob<*> {
     return this.lock.withLock { this@ThreadSafeDispatcher.dispatch(p1) }
   }
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
@@ -34,7 +34,7 @@ class ThreadSafeStore<GState>(
     }
 
     this.lock.read { this.subscribers.forEach { it.value(newState) } }
-    JustJob(newState as Any)
+    JustJob(newState)
   }
 
   override val subscribe: IReduxSubscriber<GState> = { id, callback ->

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
@@ -124,6 +124,8 @@ class SagaOutput<T : Any>(
 
   override fun timeout(millis: Long) = this.with(this.stream.timeout(millis, TimeUnit.MILLISECONDS))
 
+  override fun await(): T = this.stream.blockingFirst()
+
   override fun await(defaultValue: T): T = this.stream.blockingFirst(defaultValue)
 
   override fun awaitFor(timeoutMillis: Long): T = this.stream
@@ -133,11 +135,4 @@ class SagaOutput<T : Any>(
   override fun subscribe(onValue: (T) -> Unit, onError: (Throwable) -> Unit) {
     this.disposable.add(this.stream.subscribe(onValue, onError))
   }
-
-  /**
-   * Wait forever for the first [T] instance. Beware that if [stream] is empty, this will block
-   * infinitely.
-   * @return A [T] instance.
-   */
-  fun await(): T = this.stream.blockingFirst()
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SelectEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SelectEffect.kt
@@ -34,5 +34,5 @@ class SelectEffect<State, R>(
    * @param input A [SagaInput] instance.
    * @return A [R] instance.
    */
-  fun await(input: SagaInput) = (this.invoke(input) as SagaOutput<R>).await()
+  fun await(input: SagaInput) = this.invoke(input).await()
 }

--- a/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
+++ b/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
@@ -21,7 +21,7 @@ import static org.swiften.redux.saga.rx.SagaEffects.mapSingle;
  */
 public final class ReduxSagaTest {
   @Test
-  public void test_invokingSagaWithJava_shouldWork() {
+  public void test_invokingSagaWithJava_shouldWork() throws Exception {
     // Setup
     Object value = just(1)
       .transform(map(i -> i * 2))

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
 import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
+import org.swiften.redux.core.IAsyncJob
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.core.IStateGetter
@@ -62,7 +63,7 @@ class SagaInput(
  * emitted values.
  * @param T The emission value type.
  */
-interface ISagaOutput<T> where T : Any {
+interface ISagaOutput<T> : IAsyncJob<T> where T : Any {
   /** Trigger every time an [IReduxAction] arrives. */
   val onAction: IActionDispatcher
 
@@ -195,20 +196,6 @@ interface ISagaOutput<T> where T : Any {
    * @return An [ISagaOutput] instance.
    */
   fun timeout(millis: Long): ISagaOutput<T>
-
-  /**
-   * Wait for the first [T] that arrives, or default to [defaultValue] if the stream is empty.
-   * @param defaultValue A [T] instance.
-   * @return A [T] instance.
-   */
-  fun await(defaultValue: T): T
-
-  /**
-   * Get the next [T], but only if it arrives before [timeoutMillis].
-   * @param timeoutMillis Timeout time in milliseconds.
-   * @return A nullable [T] instance.
-   */
-  fun awaitFor(timeoutMillis: Long): T
 
   /**
    * Subscribe to values with [onValue], and error with [onError].


### PR DESCRIPTION
**IAsyncJob** can now specify return type. It also receives a few other **await** methods:

```kotlin
interface IAsyncJob<T> where T : Any {
  /**
   * Wait until some asynchronous action finishes.
   * @return A [T] instance.
   */
  fun await(): T

  /**
   * Same as [await], but return a default [T] instance if [await] errors out or is empty.
   * @param defaultValue A [T] instance.
   * @return A [T] instance.
   */
  fun await(defaultValue: T): T

  /**
   * Same as [await], but only up till [timeoutMillis]. Throw a [Throwable] otherwise.
   * @param timeoutMillis The timeout time in milliseconds.
   * @return A [T] instance.
   */
  @Throws(Exception::class)
  fun awaitFor(timeoutMillis: Long): T
}
```

**ISagaOutput** in **common-saga** also extends from **IAsyncJob** now.