### PR TITLE
Split IPropInjector and IFullPropInjector

### DIFF
--- a/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidActivity.kt
+++ b/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidActivity.kt
@@ -16,6 +16,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import org.swiften.redux.core.DefaultReduxAction
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IFullPropInjector
 import java.io.Serializable
 import java.util.Date
 
@@ -41,21 +42,21 @@ interface IBundleStateSaver<GState> {
 }
 
 /**
- * Listen to [Activity] lifecycle callbacks and perform [inject] when necessary. We can also
- * declare [saveState] and [restoreState] to handle [GState] persistence.
+ * Listen to [Activity] lifecycle callbacks and perform [inject] when necessary. We can also declare
+ * [saveState] and [restoreState] to handle [GState] persistence.
  *
  * When [Application.ActivityLifecycleCallbacks.onActivityCreated] is called, perform [inject]
  * on the [AppCompatActivity] being created, and also call [injectFragment]. This is why
  * [inject] accepts [LifecycleOwner] as its only parameter so that it can handle both
  * [AppCompatActivity] and [Fragment].
- * @receiver An [IPropInjector] instance.
+ * @receiver An [IFullPropInjector] instance.
  * @param GState The global state type.
  * @param application An [Application] instance.
  * @param saver An [IBundleStateSaver] instance.
  * @param inject Function that performs injections on [LifecycleOwner] instances passing through.
  * @return An [Application.ActivityLifecycleCallbacks] instance.
  */
-fun <GState> IPropInjector<GState>.injectActivity(
+fun <GState> IFullPropInjector<GState>.injectActivity(
   application: Application,
   saver: IBundleStateSaver<GState>,
   inject: IPropInjector<GState>.(LifecycleOwner) -> Unit
@@ -94,12 +95,13 @@ fun <GState> IPropInjector<GState>.injectActivity(
 /**
  * Similar to [injectActivity], but provides default persistence for when [GState] is
  * [Serializable].
+ * @receiver An [IFullPropInjector] instance.
  * @param GState The global state type.
  * @param application An [Application] instance.
  * @param inject Function that performs injections on [LifecycleOwner] instances passing through.
  * @return An [Application.ActivityLifecycleCallbacks] instance.
  */
-inline fun <reified GState> IPropInjector<GState>.injectActivitySerializable(
+inline fun <reified GState> IFullPropInjector<GState>.injectActivitySerializable(
   application: Application,
   noinline inject: IPropInjector<GState>.(LifecycleOwner) -> Unit
 ): Application.ActivityLifecycleCallbacks where GState : Any, GState : Serializable {
@@ -117,12 +119,13 @@ inline fun <reified GState> IPropInjector<GState>.injectActivitySerializable(
 /**
  * Similar to [injectActivity], but provides default persistence for when [GState] is
  * [Parcelable].
+ * @receiver An [IFullPropInjector] instance.
  * @param GState The global state type.
  * @param application An [Application] instance.
  * @param inject Function that performs injections on [LifecycleOwner] instances passing through.
  * @return An [Application.ActivityLifecycleCallbacks] instance.
  */
-inline fun <reified GState> IPropInjector<GState>.injectActivityParcelable(
+inline fun <reified GState> IFullPropInjector<GState>.injectActivityParcelable(
   application: Application,
   noinline inject: IPropInjector<GState>.(LifecycleOwner) -> Unit
 ): Application.ActivityLifecycleCallbacks where GState : Any, GState : Parcelable {

--- a/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidFragment.kt
+++ b/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidFragment.kt
@@ -63,6 +63,7 @@ internal fun <GState> IPropInjector<GState>.injectFragment(
 
 /**
  * Call [injectFragment] with an [AppCompatActivity].
+ * @receiver An [IPropInjector] instance.
  * @param GState The global state type.
  * @param activity An [AppCompatActivity] instance.
  * @param inject Function that performs injections on [LifecycleOwner] instances passing through.

--- a/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidLifecycle.kt
+++ b/android/android-lifecycle/src/main/java/org/swiften/redux/android/ui/lifecycle/AndroidLifecycle.kt
@@ -10,8 +10,9 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.OnLifecycleEvent
 import org.swiften.redux.core.IReduxSubscription
-import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IFullPropInjector
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ReduxProp
@@ -22,7 +23,7 @@ import org.swiften.redux.ui.StaticProp
 interface ILifecycleCallback {
   /**
    * This method will be called when it is safe to perform lifecycle-aware tasks, such as
-   * [IPropInjector.inject].
+   * [IFullPropInjector.inject].
    */
   fun onSafeForStartingLifecycleAwareTasks()
 
@@ -81,7 +82,7 @@ open class ReduxLifecycleObserver(
 }
 
 /**
- * Call [IPropInjector.inject] for [lifecycleOwner].
+ * Call [IFullPropInjector.inject] for [lifecycleOwner].
  * @receiver An [IPropInjector] instance.
  * @param GState The global state type.
  * @param LState The local state type that [GState] must extend from.
@@ -109,7 +110,7 @@ fun <GState, LState, Owner, OutProp, State, Action> IPropInjector<GState>.inject
   var subscription: IReduxSubscription? = null
 
   /**
-   * We perform [IPropInjector.inject] in [ReduxLifecycleObserver.onStart] because by then
+   * We perform [IFullPropInjector.inject] in [ReduxLifecycleObserver.onStart] because by then
    * the views would have been initialized, and thus can be accessed in
    * [IPropLifecycleOwner.beforePropInjectionStarts]. To mirror this, unsubscription is done in
    * [ReduxLifecycleObserver.onStop] because said views are not destroyed yet.
@@ -141,7 +142,9 @@ fun <GState, LState, Owner, OutProp, State, Action> IPropInjector<GState>.inject
         }, mapper)
     }
 
-    override fun onSafeForEndingLifecycleAwareTasks() { subscription?.unsubscribe() }
+    override fun onSafeForEndingLifecycleAwareTasks() {
+      subscription?.unsubscribe()
+    }
   })
 
   return lifecycleOwner

--- a/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
+++ b/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
@@ -16,7 +16,7 @@ import org.swiften.redux.core.IStateGetter
 import org.swiften.redux.core.ReduxSubscription
 import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.IPropContainer
-import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IFullPropInjector
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.ObservableReduxProp
@@ -56,7 +56,7 @@ open class BaseLifecycleTest {
     override fun getLifecycle(): Lifecycle = this.registry
   }
 
-  class TestInjector(override val lastState: IStateGetter<Int> = { 0 }) : IPropInjector<Int> {
+  class TestInjector(override val lastState: IStateGetter<Int> = { 0 }) : IFullPropInjector<Int> {
     val subscriptions: MutableList<IReduxSubscription> = synchronizedList(mutableListOf())
     val injectionCount get() = this.subscriptions.size
 
@@ -75,7 +75,7 @@ open class BaseLifecycleTest {
       val subscription = ReduxSubscription("$view") { view.afterPropInjectionEnds() }
       val state = mapper.mapState(lastState as LState, outProp)
       val action = mapper.mapAction(this.dispatch, outProp)
-      view.beforePropInjectionStarts(StaticProp(this as IPropInjector<LState>, outProp))
+      view.beforePropInjectionStarts(StaticProp(this as IFullPropInjector<LState>, outProp))
       view.reduxProp = ReduxProp(subscription, state, action)
       this.subscriptions.add(subscription)
       return subscription

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
@@ -11,11 +11,12 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.swiften.redux.core.CompositeReduxSubscription
 import org.swiften.redux.core.ReduxSubscription
-import org.swiften.redux.ui.NoopPropLifecycleOwner
-import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IFullPropInjector
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
+import org.swiften.redux.ui.NoopPropLifecycleOwner
 import org.swiften.redux.ui.ObservableReduxProp
 import org.swiften.redux.ui.ReduxProp
 import org.swiften.redux.ui.StaticProp
@@ -133,7 +134,7 @@ abstract class ReduxListAdapter<GState, LState, OutProp, VH, VHState, VHAction>(
  * [adapter] does not have to be a [ListAdapter] - it can be any [RecyclerView.Adapter] as long as
  * it implements [RecyclerView.Adapter.onCreateViewHolder].
  *
- * Since we do not call [IPropInjector.inject] directly into [VH], we cannot use
+ * Since we do not call [IFullPropInjector.inject] directly into [VH], we cannot use
  * [IPropMapper.mapAction] on [VH] itself. As a result, we must pass down
  * [ReduxProp.action] from [ReduxListAdapter.reduxProp] into each [VH] instance. The [VHAction]
  * should contain actions that take at least one [Int] parameter, (e.g. (Int) -> Unit), so that we
@@ -141,6 +142,7 @@ abstract class ReduxListAdapter<GState, LState, OutProp, VH, VHState, VHAction>(
  *
  * Note that this does not support lifecycle handling, so we will need to manually set null via
  * [RecyclerView.setAdapter] to invoke [RecyclerView.Adapter.onDetachedFromRecyclerView].
+ * @receiver An [IPropInjector] instance.
  * @param GState The global state type.
  * @param OutProp Property as defined by [adapter]'s parent.
  * @param VH The [RecyclerView.ViewHolder] instance.

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/LifecycleAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/LifecycleAdapter.kt
@@ -11,8 +11,8 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.swiften.redux.android.ui.lifecycle.ILifecycleCallback
 import org.swiften.redux.android.ui.lifecycle.ReduxLifecycleObserver
-import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
@@ -8,8 +8,9 @@ package org.swiften.redux.android.ui.recyclerview
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import org.swiften.redux.core.CompositeReduxSubscription
-import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IFullPropInjector
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.IStateMapper
@@ -20,7 +21,7 @@ import java.util.Date
 /** Created by haipham on 2019/01/08 */
 /**
  * Convenience [RecyclerView.Adapter] that implements some default methods to make working with
- * [IPropInjector] easier. Basically, [RecyclerView.Adapter.getItemCount] always returns 0
+ * [IFullPropInjector] easier. Basically, [RecyclerView.Adapter.getItemCount] always returns 0
  * (because it will be delegated to a different calculation.
  *
  * This class is not required because custom [RecyclerView.Adapter] only needs to do the same as
@@ -111,7 +112,7 @@ abstract class DelegateRecyclerAdapter<GState, LState, OutProp, VH, VHState, VHA
   }
 
   /**
-   * Since we will be performing [IPropInjector.inject] for [VH] instances, we will be using
+   * Since we will be performing [IFullPropInjector.inject] for [VH] instances, we will be using
    * [CompositeReduxSubscription.add] a lot every time [RecyclerView.Adapter.onBindViewHolder] is
    * called. As a result, calling this method will ensure proper deinitialization.
    */

--- a/android/android-ui/src/test/java/org/swiften/redux/android/ui/AndroidInjectorTest.kt
+++ b/android/android-ui/src/test/java/org/swiften/redux/android/ui/AndroidInjectorTest.kt
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.swiften.redux.android.util.AndroidUtil
 import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.ui.IPropContainer
-import org.swiften.redux.ui.IPropInjector
+import org.swiften.redux.ui.IFullPropInjector
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.PropInjectorTest
 import org.swiften.redux.ui.ReduxProp
@@ -68,7 +68,7 @@ class AndroidInjectorTest : PropInjectorTest() {
     override fun afterPropInjectionEnds() { this.afterInjectionCount.incrementAndGet() }
   }
 
-  override fun createInjector(store: IReduxStore<S>): IPropInjector<S> {
+  override fun createInjector(store: IReduxStore<S>): IFullPropInjector<S> {
     return AndroidPropInjector(store, this.runner)
   }
 

--- a/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
+++ b/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
@@ -84,7 +84,7 @@ open class PropInjectorTest {
     }
   }
 
-  open fun createInjector(store: IReduxStore<S>): IPropInjector<S> {
+  open fun createInjector(store: IReduxStore<S>): IFullPropInjector<S> {
     return TestInjector(store)
   }
 


### PR DESCRIPTION
The original **IPropInjector** extends many interfaces, most of which are not required to be in **StaticProp**. We now have an **IFullPropInjector** interface that provides all functionalities, while **StaticProp** receives **IPropInjector**. Most extension methods are now anchored to **IPropInjector**.