### PR TITLE
Non null prop (state/action) in ReduxProp

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,14 @@ class Fragment1 : Fragment(),
   IPropContainer<State, Action>,
   IPropLifecycleOwner<GlobalState, Unit> {
   override var reduxProps by ObservableReduxProps<State, Action> { _, next ->
-    println(next.state?.query)
+    println(next.state.query)
   }
 
   // This is one of the only two lifecycle methods that you will need to worry about.
   override fun beforePropInjectionStarts(...) {
     this.search_query.addTextChangedListener(object : TextWatcher() {
       override fun onTextChanged(s: CharSequence?, ...) {
-        this@Fragment1.reduxProps.action?.updateQuery?.invoke(s?.toString())
+        this@Fragment1.reduxProps.action.updateQuery(s?.toString())
       }
     })
   }
@@ -326,11 +326,8 @@ class Fragment2 : Fragment(),
   }
 
   override val reduxProps by ObservableReduxProps<State, Action> { _, next ->
-    next.state?.imageURL?.also { url ->
-      next.action?.picasso?.also { picasso ->
-        picasso.load(url).into(this.image_view)
-      }
-    }
+    val imageURL = next.state.imageURL
+    next.action.picasso.load(imageURL).into(this.image_view)
   }
 }
 

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
@@ -11,9 +11,9 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.swiften.redux.core.CompositeReduxSubscription
 import org.swiften.redux.core.ReduxSubscription
-import org.swiften.redux.ui.IPropInjector
-import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IFullPropInjector
+import org.swiften.redux.ui.IPropContainer
+import org.swiften.redux.ui.IPropInjector
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
 import org.swiften.redux.ui.NoopPropLifecycleOwner
@@ -70,7 +70,7 @@ abstract class ReduxListAdapter<GState, LState, OutProp, VH, VHState, VHAction>(
    * safely access [ReduxProp.action] in [onBindViewHolder].
    */
   override var reduxProp by ObservableReduxProp<List<VHState>, VHAction> { _, next ->
-    this.submitList(next.state ?: arrayListOf())
+    this.submitList(next.state)
   }
 
   override fun beforePropInjectionStarts(sp: StaticProp<LState, OutProp>) {

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
@@ -38,6 +38,6 @@ data class StaticProp<LState, OutProp>(
  */
 data class ReduxProp<State, Action>(
   val subscription: IReduxSubscription,
-  override val state: State?,
-  override val action: Action?
+  override val state: State,
+  override val action: Action
 ) : IVariableProp<State, Action> where State : Any, Action : Any

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
@@ -14,8 +14,8 @@ import org.swiften.redux.core.IReduxSubscription
  * @param Action Action type that handles view interactions.
  */
 interface IVariableProp<out State, out Action> where State : Any, Action : Any {
-  val state: State?
-  val action: Action?
+  val state: State
+  val action: Action
 }
 
 /**

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/DetailFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/DetailFragment.kt
@@ -36,7 +36,7 @@ class DetailFragment : Fragment(),
   data class S(val track: MusicTrack?)
 
   override var reduxProp by ObservableReduxProp<S, Unit> { _, next ->
-    next.state?.track?.also {
+    next.state.track?.also {
       this.trackName.text = it.trackName
       this.artistName.text = it.artistName
     }

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
@@ -42,7 +42,7 @@ class MainFragment : Fragment(),
   class A(val selectPage: (Int) -> Unit)
 
   override var reduxProp by ObservableReduxProp<S, A> { _, next ->
-    next.state?.also { this.view_pager.currentItem = it.selectedPage }
+    next.state.also { this.view_pager.currentItem = it.selectedPage }
   }
 
   override fun onCreateView(
@@ -74,7 +74,7 @@ class MainFragment : Fragment(),
         ) {}
 
         override fun onPageSelected(position: Int) {
-          this@MainFragment.reduxProp.action?.selectPage?.invoke(position)
+          this@MainFragment.reduxProp.action.selectPage(position)
         }
       })
     }

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/SearchFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/SearchFragment.kt
@@ -61,7 +61,7 @@ class SearchAdapter : ReduxRecyclerViewAdapter<SearchAdapter.ViewHolder>() {
     IPropContainer<S, A>,
     IPropLifecycleOwner<ILocalState, Unit> by NoopPropLifecycleOwner() {
     override var reduxProp by ObservableReduxProp<S, A> { _, next ->
-      next.state?.track?.also {
+      next.state.track?.also {
         this.trackName.text = it.trackName
         this.artistName.text = it.artistName
       }
@@ -72,7 +72,7 @@ class SearchAdapter : ReduxRecyclerViewAdapter<SearchAdapter.ViewHolder>() {
 
     override fun beforePropInjectionStarts(sp: StaticProp<ILocalState, Unit>) {
       this.itemView.setOnClickListener {
-        this@ViewHolder.reduxProp.action?.selectTrack?.invoke(this@ViewHolder.layoutPosition)
+        this@ViewHolder.reduxProp.action.selectTrack(this@ViewHolder.layoutPosition)
       }
     }
   }
@@ -111,9 +111,7 @@ class SearchFragment : Fragment(),
   class A(val updateQuery: (String?) -> Unit, val updateLimit: (ResultLimit?) -> Unit)
 
   override var reduxProp by ObservableReduxProp<S, A> { _, next ->
-    next.state?.also {
-      this.progress_bar.visibility = if (it.loading) View.VISIBLE else View.INVISIBLE
-    }
+    this.progress_bar.visibility = if (next.state.loading) View.VISIBLE else View.INVISIBLE
   }
 
   override fun onCreateView(
@@ -127,7 +125,7 @@ class SearchFragment : Fragment(),
 
     this.search_query.addTextChangedListener(object : TextWatcher {
       override fun afterTextChanged(s: Editable?) {
-        this@SearchFragment.reduxProp.action?.updateQuery?.invoke(s?.toString())
+        this@SearchFragment.reduxProp.action.updateQuery(s?.toString())
       }
 
       override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
@@ -159,7 +157,7 @@ class SearchFragment : Fragment(),
 
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
           val selectedLimit = selectableLimits.elementAtOrNull(position)
-          this@SearchFragment.reduxProp.action?.updateLimit?.invoke(selectedLimit)
+          this@SearchFragment.reduxProp.action.updateLimit(selectedLimit)
         }
       }
     }

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -50,18 +50,16 @@ class GardenFragment : Fragment(),
   }
 
   override var reduxProp by ObservableReduxProp<S, Unit> { prev, next ->
-    next.state?.also {
-      if (it.gardenPlantingCount == 0) {
-        this.garden_list.visibility = View.GONE
-        this.empty_garden.visibility = View.VISIBLE
-      } else {
-        this.garden_list.visibility = View.VISIBLE
-        this.empty_garden.visibility = View.GONE
-      }
+    if (next.state.gardenPlantingCount == 0) {
+      this.garden_list.visibility = View.GONE
+      this.empty_garden.visibility = View.VISIBLE
+    } else {
+      this.garden_list.visibility = View.VISIBLE
+      this.empty_garden.visibility = View.GONE
+    }
 
-      if (it.gardenPlantingCount != prev?.state?.gardenPlantingCount) {
-        this.garden_list.adapter?.notifyDataSetChanged()
-      }
+    if (next.state.gardenPlantingCount != prev?.state?.gardenPlantingCount) {
+      this.garden_list.adapter?.notifyDataSetChanged()
     }
   }
 

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -77,21 +77,20 @@ class PlantDetailFragment : Fragment(),
   }
 
   override var reduxProp by ObservableReduxProp<S, A> { _, next ->
-    next.state?.plant?.also { p ->
+    next.state.plant?.also { p ->
       this.shareText = this.getString(R.string.share_text_plant, p.name)
       this.plant_watering.text = this.context?.let { this.bindWateringText(it, p.wateringInterval) }
       this.plant_detail.text = HtmlCompat.fromHtml(p.description, HtmlCompat.FROM_HTML_MODE_COMPACT)
       this.toolbar_layout.title = p.name
 
-      next.action?.picasso?.also {
-        it.load(p.imageUrl)
-          .centerCrop()
-          .resize(LARGE_IMAGE_DIMEN, LARGE_IMAGE_DIMEN)
-          .into(this.detail_image)
-      }
+      next.action.picasso
+        .load(p.imageUrl)
+        .centerCrop()
+        .resize(LARGE_IMAGE_DIMEN, LARGE_IMAGE_DIMEN)
+        .into(this.detail_image)
     }
 
-    next.state?.isPlanted?.also { this.fab.visibility = if (it) View.GONE else View.VISIBLE }
+    next.state.isPlanted?.also { this.fab.visibility = if (it) View.GONE else View.VISIBLE }
   }
 
   private var shareText: String = ""
@@ -139,7 +138,7 @@ class PlantDetailFragment : Fragment(),
 
   override fun beforePropInjectionStarts(sp: StaticProp<Redux.State, IDependency>) {
     this.fab.setOnClickListener {
-      this.reduxProp.action?.addPlantToGarden?.invoke()
+      this.reduxProp.action.addPlantToGarden()
       Snackbar.make(it, R.string.added_plant_to_garden, Snackbar.LENGTH_LONG).show()
     }
   }

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -55,7 +55,7 @@ class PlantListFragment : Fragment(),
   }
 
   override var reduxProp by ObservableReduxProp<S, A> { prev, next ->
-    if (next.state?.plantCount != prev?.state?.plantCount) {
+    if (next.state.plantCount != prev?.state?.plantCount) {
       this.plant_list.adapter?.notifyDataSetChanged()
     }
   }
@@ -77,7 +77,7 @@ class PlantListFragment : Fragment(),
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
     return when (item.itemId) {
       R.id.filter_zone -> {
-        this.reduxProp.action?.updateGrowZone?.invoke()
+        this.reduxProp.action.updateGrowZone()
         true
       }
       else -> super.onOptionsItemSelected(item)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
@@ -75,7 +75,7 @@ class GardenPlantingAdapter : ReduxRecyclerViewAdapter<GardenPlantingAdapter.Vie
     }
 
     override var reduxProp by ObservableReduxProp<S, A> { _, next ->
-      next.state?.plantings?.also { p ->
+      next.state.plantings?.also { p ->
         if (p.gardenPlantings.isNotEmpty()) {
           val context = this.itemView.context
           val gardenPlanting = p.gardenPlantings[0]
@@ -93,12 +93,11 @@ class GardenPlantingAdapter : ReduxRecyclerViewAdapter<GardenPlantingAdapter.Vie
           this.plantDate.text = context.getString(R.string.planted_date, p.plant.name, plantDateStr)
           this.waterDate.text = wateringStr
 
-          next.action?.picasso?.also {
-            it.load(p.plant.imageUrl)
-              .centerCrop()
-              .resize(SMALL_IMAGE_DIMEN, SMALL_IMAGE_DIMEN)
-              .into(this.imageView)
-          }
+          next.action.picasso
+            .load(p.plant.imageUrl)
+            .centerCrop()
+            .resize(SMALL_IMAGE_DIMEN, SMALL_IMAGE_DIMEN)
+            .into(this.imageView)
         }
       }
     }
@@ -110,7 +109,7 @@ class GardenPlantingAdapter : ReduxRecyclerViewAdapter<GardenPlantingAdapter.Vie
 
     override fun beforePropInjectionStarts(sp: StaticProp<Redux.State, PositionProp<IDependency>>) {
       this.itemView.setOnClickListener {
-        this@ViewHolder.reduxProp.action?.goToPlantDetail?.invoke()
+        this@ViewHolder.reduxProp.action.goToPlantDetail()
       }
     }
   }

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
@@ -81,21 +81,18 @@ class PlantAdapter : ReduxRecyclerViewAdapter<PlantAdapter.ViewHolder>() {
 
     init {
       this.itemView.setOnClickListener {
-        this@ViewHolder.reduxProp.action?.goToPlantDetail?.invoke(this.layoutPosition)
+        this@ViewHolder.reduxProp.action.goToPlantDetail(this.layoutPosition)
       }
     }
 
     override var reduxProp by ObservableReduxProp<Plant, A> { _, next ->
-      next.state?.also { state ->
-        this.title.text = state.name
+      this.title.text = next.state.name
 
-        next.action?.picasso?.also {
-          it.load(state.imageUrl)
-            .centerCrop()
-            .resize(SMALL_IMAGE_DIMEN, SMALL_IMAGE_DIMEN)
-            .into(this.image)
-        }
-      }
+      next.action.picasso
+        .load(next.state.imageUrl)
+        .centerCrop()
+        .resize(SMALL_IMAGE_DIMEN, SMALL_IMAGE_DIMEN)
+        .into(this.image)
     }
   }
 }


### PR DESCRIPTION
**ReduxProp** used to have nullable **state**/**action**. With the update to prop injector, **ReduxProp.state** and **ReduxProp.action** will never be null as long as they are accessed after **beforePropInjectionStarts**. What used to be:

```kotlin
override val reduxProp by ObservableReduxProp<S, A> { _, next ->
  println(next.state?.query)
}

// View interaction
this.reduxProp.action?.navigate?.invoke()
```

Now becomes:

```kotlin
override val reduxProp by ObservableReduxProp<S, A> { _, next ->
  println(next.state.query)
}

// View interaction
this.reduxProp.action.navigate()
```

This makes code much cleaner.