### PR TITLE
Allow reducer to specify action type

### DIFF
--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
@@ -13,8 +13,9 @@ typealias IActionDispatcher = (IReduxAction) -> IAsyncJob<*>
  * Represents a Redux reducer that reduce a [IReduxAction] onto a previous state to produce a new
  * state.
  * @param GState The global state type.
+ * @param Action The [IReduxAction] type.
  */
-typealias IReducer<GState> = (GState, IReduxAction) -> GState
+typealias IReducer<GState, Action> = (GState, Action) -> GState
 
 /**
  * Get the last internal state.
@@ -46,9 +47,10 @@ interface IReduxActionWithKey : IReduxAction {
 /**
  * Represents an object that provides [IReducer].
  * @param GState The global state type.
+ * @param Action The [IReduxAction] type.
  */
-interface IReducerProvider<GState> where GState : Any {
-  val reducer: IReducer<GState>
+interface IReducerProvider<GState, Action> where GState : Any, Action : IReduxAction {
+  val reducer: IReducer<GState, Action>
 }
 
 /** Represents an object that provides [IActionDispatcher]. */
@@ -88,7 +90,7 @@ interface IReduxUnsubscriberProvider {
  * @param GState The global state type.
  */
 interface IReduxStore<GState> :
-  IReducerProvider<GState>,
+  IReducerProvider<GState, IReduxAction>,
   IDispatcherProvider,
   IStateGetterProvider<GState>,
   IReduxSubscriberProvider<GState>,

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/DefaultActionStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/DefaultActionStore.kt
@@ -12,7 +12,7 @@ package org.swiften.redux.core
  * @param state See [ThreadSafeStore.state].
  * @param reducer See [ThreadSafeStore.reducer].
  */
-class DefaultActionStore<GState>(state: GState, reducer: IReducer<GState>) :
+class DefaultActionStore<GState>(state: GState, reducer: IReducer<GState, IReduxAction>) :
   IReduxStore<GState> where GState : Any {
   private val store: IReduxStore<GState>
   init { this.store = ThreadSafeStore(state, ReduxReducerWrapper(reducer)) }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/FinalStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/FinalStore.kt
@@ -14,7 +14,7 @@ package org.swiften.redux.core
  */
 class FinalStore<GState : Any> private constructor(store: IReduxStore<GState>) :
   IReduxStore<GState> by store {
-  constructor(state: GState, reducer: IReducer<GState>) :
+  constructor(state: GState, reducer: IReducer<GState, IReduxAction>) :
     this(fun (): IReduxStore<GState> {
       return DefaultActionStore(state, reducer)
     }())

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Preset.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Preset.kt
@@ -24,8 +24,8 @@ sealed class DefaultReduxAction : IReduxAction {
  * @param GState The global state type.
  * @param reducer See [IReduxStore.reducer].
  */
-class ReduxReducerWrapper<GState>(private val reducer: IReducer<GState>) :
-  IReducer<GState> by reducer {
+class ReduxReducerWrapper<GState>(private val reducer: IReducer<GState, IReduxAction>) :
+  IReducer<GState, IReduxAction> by reducer {
   @Suppress("UNCHECKED_CAST")
   @Throws(ClassCastException::class)
   override operator fun invoke(previous: GState, action: IReduxAction): GState {

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
@@ -19,7 +19,7 @@ import kotlin.concurrent.write
  */
 class ThreadSafeStore<GState>(
   private var state: GState,
-  override val reducer: IReducer<GState>
+  override val reducer: IReducer<GState, IReduxAction>
 ) : IReduxStore<GState> where GState : Any {
   private val lock = ReentrantReadWriteLock()
   private val subscribers = HashMap<String, (GState) -> Unit>()

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseStoreTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseStoreTest.kt
@@ -64,7 +64,7 @@ abstract class BaseStoreTest : CoroutineScope {
 
   override val coroutineContext = Dispatchers.Default
 
-  fun reducer(): IReducer<Int> = { s, a -> when (a) { is Action -> a(s); else -> s } }
+  fun reducer(): IReducer<Int, IReduxAction> = { s, a -> when (a) { is Action -> a(s); else -> s } }
 
   abstract fun createStore(): IReduxStore<Int>
 

--- a/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
+++ b/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
@@ -185,7 +185,7 @@ class SagaEffectTest : CommonSagaEffectTest() {
       override val key: String get() = "Action2"
     }
 
-    val reducer: IReducer<State> = { state, action ->
+    val reducer: IReducer<State, IReduxAction> = { state, action ->
       when (action) {
         is Action1 -> state.copy(a1 = action.value)
         is Action2 -> state.copy(a2 = action.value)
@@ -193,7 +193,7 @@ class SagaEffectTest : CommonSagaEffectTest() {
       }
     }
 
-    val enhancedReducer: IReducer<State> = { s, a -> val newState = reducer(s, a); newState }
+    val enhancedReducer: IReducer<State, IReduxAction> = { s, a -> val newState = reducer(s, a); newState }
     var store: IReduxStore<State>? = null
     val finalValues = synchronizedList(arrayListOf<Pair<State, State>>())
 

--- a/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/Redux.kt
+++ b/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/Redux.kt
@@ -27,7 +27,7 @@ object Redux {
     object Screen3 : Screen()
   }
 
-  object Reducer : IReducer<State> {
+  object Reducer : IReducer<State, IReduxAction> {
     override fun invoke(p1: State, p2: IReduxAction): State {
       return when (p2) {
         is Business1Redux.Action -> p1.copy(business1 = Business1Redux.Reducer(p1.business1, p2))

--- a/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/business1/Business1Redux.kt
+++ b/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/business1/Business1Redux.kt
@@ -20,8 +20,8 @@ object Business1Redux {
     data class SetQuery(val query: String?) : Action()
   }
 
-  object Reducer : IReducer<State> {
-    override fun invoke(p1: State, p2: IReduxAction): State {
+  object Reducer : IReducer<State, Action> {
+    override fun invoke(p1: State, p2: Action): State {
       return p1
     }
   }

--- a/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/business2/Business2Redux.kt
+++ b/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/business2/Business2Redux.kt
@@ -17,8 +17,8 @@ object Business2Redux {
 
   sealed class Action : IReduxAction
 
-  object Reducer : IReducer<Business2Redux.State> {
-    override fun invoke(p1: Business2Redux.State, p2: IReduxAction): Business2Redux.State {
+  object Reducer : IReducer<State, Action> {
+    override fun invoke(p1: State, p2: Action): Business2Redux.State {
       return p1
     }
   }

--- a/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/business3/Business3Redux.kt
+++ b/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/business3/Business3Redux.kt
@@ -17,8 +17,8 @@ object Business3Redux {
 
   sealed class Action : IReduxAction
 
-  object Reducer : IReducer<Business3Redux.State> {
-    override fun invoke(p1: Business3Redux.State, p2: IReduxAction): Business3Redux.State {
+  object Reducer : IReducer<State, Action> {
+    override fun invoke(p1: State, p2: Action): Business3Redux.State {
       return p1
     }
   }

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/Redux.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/Redux.kt
@@ -66,7 +66,7 @@ object Redux {
     data class UpdateSelectedTrack(val index: Int?) : Action()
   }
 
-  object Reducer : IReducer<State> {
+  object Reducer : IReducer<State, IReduxAction> {
     override fun invoke(p1: State, p2: IReduxAction): State {
       return when (p2) {
         is Action -> when (p2) {

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/dependency/Redux.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/dependency/Redux.kt
@@ -112,7 +112,7 @@ object Redux {
     class PlantListToPlantDetail(val plantId: String) : Screen()
   }
 
-  object Reducer : IReducer<State> {
+  object Reducer : IReducer<State, IReduxAction> {
     override fun invoke(p1: State, p2: IReduxAction): State {
       return when (p2) {
         is Action -> when (p2) {


### PR DESCRIPTION
Allow **IReducer** to specify action type:

```kotlin
typealias IReducer<State, Action> = (State, Action) -> State
```

This is useful for breaking a big reducer into multiple smaller ones with specific action types.