### PR TITLE
Saga monitor for central output action dispatch

### DIFF
--- a/android/android-livedata-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/livedata/TakeEveryEffect.kt
+++ b/android/android-livedata-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/livedata/TakeEveryEffect.kt
@@ -40,6 +40,6 @@ internal class TakeEveryEffect<R>(private val creator: () -> LiveData<R>) : Saga
       .toFlowable(BackpressureStrategy.BUFFER)
       .serialize()
 
-    return SagaOutput(p1.scope, stream) { EmptyJob }
+    return SagaOutput(p1.scope, p1.monitor, stream) { EmptyJob }
   }
 }

--- a/android/android-livedata-rx-saga/src/test/java/org/swiften/redux/android/saga/rx/livedata/LiveDataEffectTest.kt
+++ b/android/android-livedata-rx-saga/src/test/java/org/swiften/redux/android/saga/rx/livedata/LiveDataEffectTest.kt
@@ -7,6 +7,7 @@ package org.swiften.redux.android.saga.rx.livedata
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -18,6 +19,9 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.swiften.redux.android.saga.rx.livedata.LiveDataEffects.takeEveryData
+import org.swiften.redux.core.EmptyJob
+import org.swiften.redux.saga.common.SagaInput
+import org.swiften.redux.saga.common.SagaMonitor
 import org.swiften.redux.saga.common.filter
 import org.swiften.redux.saga.common.mapAsync
 import java.util.Collections
@@ -38,7 +42,7 @@ class LiveDataEffectTest {
     takeEveryData { data }
       .mapAsync { this.async { delay(1000); it } }
       .filter { it % 2 == 0 }
-      .invoke()
+      .invoke(SagaInput(GlobalScope, SagaMonitor(), { Unit }) { EmptyJob })
       .subscribe({ finalValues.add(it) })
 
     // When

--- a/android/android-livedata-rx-saga/src/test/java/org/swiften/redux/android/saga/rx/livedata/LiveDataEffectTest.kt
+++ b/android/android-livedata-rx-saga/src/test/java/org/swiften/redux/android/saga/rx/livedata/LiveDataEffectTest.kt
@@ -36,13 +36,14 @@ class LiveDataEffectTest {
   @Test
   fun test_takeEveryDataEffect_shouldStreamLiveData() {
     // Setup
+    val monitor = SagaMonitor()
     val data = MutableLiveData<Int>()
     val finalValues = Collections.synchronizedList(arrayListOf<Int>())
 
     takeEveryData { data }
       .mapAsync { this.async { delay(1000); it } }
       .filter { it % 2 == 0 }
-      .invoke(SagaInput(GlobalScope, SagaMonitor(), { Unit }) { EmptyJob })
+      .invoke(SagaInput(GlobalScope, monitor, { Unit }) { EmptyJob })
       .subscribe({ finalValues.add(it) })
 
     // When

--- a/android/android-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/core/WatchConnectivityEffect.kt
+++ b/android/android-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/core/WatchConnectivityEffect.kt
@@ -67,6 +67,6 @@ internal class WatchConnectivityEffect(private val context: Context) : SagaEffec
       }
     }
 
-    return SagaOutput(p1.scope, stream.toFlowable(BackpressureStrategy.BUFFER)) { EmptyJob }
+    return SagaOutput(p1.scope, p1.monitor, stream.toFlowable(BackpressureStrategy.BUFFER)) { EmptyJob }
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/AllEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/AllEffect.kt
@@ -19,6 +19,6 @@ import org.swiften.redux.saga.common.SagaInput
 internal class AllEffect<R>(private val sources: Collection<SagaEffect<R>>) : SagaEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
     val sourceOutputs = this.sources.map { (it.invoke(p1) as SagaOutput<R>) }
-    return SagaOutput.merge(p1.scope, sourceOutputs)
+    return SagaOutput.merge(p1.scope, p1.monitor, sourceOutputs)
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/AwaitEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/AwaitEffect.kt
@@ -24,6 +24,6 @@ typealias IAwaitCreator<R> = suspend CoroutineScope.(SagaInput) -> R
  */
 internal class AwaitEffect<R>(private val creator: IAwaitCreator<R>) : SingleSagaEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
-    return SagaOutput.from(p1.scope) { this@AwaitEffect.creator(this, p1) }
+    return SagaOutput.from(p1.scope, p1.monitor) { this@AwaitEffect.creator(this, p1) }
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/CallEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/CallEffect.kt
@@ -25,6 +25,6 @@ internal class CallEffect<P, R>(
   private val transformer: (P) -> Single<R>
 ) : SagaEffect<R>() where P : Any, R : Any {
   override fun invoke(p1: SagaInput) = this.source.invoke(p1).flatMap {
-    SagaOutput(p1.scope, this.transformer(it).toFlowable()) { EmptyJob }
+    SagaOutput(p1.scope, p1.monitor, this.transformer(it).toFlowable()) { EmptyJob }
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/FromEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/FromEffect.kt
@@ -7,6 +7,7 @@ package org.swiften.redux.saga.rx
 
 import io.reactivex.Flowable
 import org.swiften.redux.core.EmptyJob
+import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
 
@@ -19,5 +20,7 @@ import org.swiften.redux.saga.common.SagaInput
 internal class FromEffect<R>(
   private val stream: Flowable<R>
 ) : SagaEffect<R>() where R : Any {
-  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, this.stream) { EmptyJob }
+  override fun invoke(p1: SagaInput): ISagaOutput<R> {
+    return SagaOutput(p1.scope, p1.monitor, this.stream) { EmptyJob }
+  }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
@@ -7,6 +7,7 @@ package org.swiften.redux.saga.rx
 
 import io.reactivex.Flowable.just
 import org.swiften.redux.core.EmptyJob
+import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
 import org.swiften.redux.saga.common.SingleSagaEffect
@@ -18,5 +19,7 @@ import org.swiften.redux.saga.common.SingleSagaEffect
  * @param value The [R] value to be emitted.
  */
 internal class JustEffect<R>(private val value: R) : SingleSagaEffect<R>() where R : Any {
-  override fun invoke(p1: SagaInput) = SagaOutput(p1.scope, just(this.value)) { EmptyJob }
+  override fun invoke(p1: SagaInput): ISagaOutput<R> {
+    return SagaOutput(p1.scope, p1.monitor, just(this.value)) { EmptyJob }
+  }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/NothingEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/NothingEffect.kt
@@ -19,6 +19,6 @@ import org.swiften.redux.saga.common.SagaInput
  */
 internal class NothingEffect<R> : SagaEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
-    return SagaOutput(p1.scope, Flowable.empty()) { EmptyJob }
+    return SagaOutput(p1.scope, p1.monitor, Flowable.empty()) { EmptyJob }
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/RxTakeEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/RxTakeEffect.kt
@@ -33,7 +33,7 @@ internal abstract class RxTakeEffect<Action, P, R>(
   override operator fun invoke(p1: SagaInput): ISagaOutput<R> {
     val subject = PublishProcessor.create<P>().toSerialized()
 
-    val nested = SagaOutput(p1.scope, subject) { a ->
+    val nested = SagaOutput(p1.scope, p1.monitor, subject) { a ->
       if (cls.isInstance(a)) {
         this@RxTakeEffect.extractor(cls.cast(a))?.also { subject.onNext(it) }
       }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
@@ -74,8 +74,8 @@ class SagaOutput<T : Any>(
 
   init {
     val subscriberID = this.uniqueSubscriberID
-    this.monitor.set(subscriberID, this.onAction)
-    this.stream = stream.doOnCancel { this@SagaOutput.monitor.remove(subscriberID) }
+    this.monitor.setOutputDispatcher(subscriberID, this.onAction)
+    this.stream = stream.doOnCancel { this@SagaOutput.monitor.removeOutputDispatcher(subscriberID) }
   }
 
   private fun <T2> with(newStream: Flowable<T2>): ISagaOutput<T2> where T2 : Any {

--- a/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
+++ b/common/common-rx-saga/src/test/java/org/swiften/redux/saga/rx/ReduxSagaTest.java
@@ -9,6 +9,8 @@ import io.reactivex.Single;
 import kotlinx.coroutines.GlobalScope;
 import org.junit.Test;
 import org.swiften.redux.core.EmptyJob;
+import org.swiften.redux.saga.common.SagaInput;
+import org.swiften.redux.saga.common.SagaMonitor;
 
 import static org.junit.Assert.assertEquals;
 import static org.swiften.redux.saga.common.CommonEffects.map;
@@ -27,7 +29,7 @@ public final class ReduxSagaTest {
       .transform(map(i -> i * 2))
       .transform(mapSingle(i -> Single.just(i * 3)))
       .transform(retryMultipleTimes(3))
-      .invoke(GlobalScope.INSTANCE, 0, a -> EmptyJob.INSTANCE)
+      .invoke(new SagaInput(GlobalScope.INSTANCE, new SagaMonitor(), () -> 0, a -> EmptyJob.INSTANCE))
       .awaitFor(1000);
 
     // When && Then

--- a/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
+++ b/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
@@ -443,4 +443,11 @@ class SagaEffectTest : CommonSagaEffectTest() {
       ))
     }
   }
+
+  @Test
+  fun `Stream disposition should remove entry from monitor`() {
+    test_streamDisposition_shouldRemoveEntryFromMonitor { creator ->
+      takeLatest(IReduxAction::class, { it }, creator)
+    }
+  }
 }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -13,6 +13,7 @@ import org.swiften.redux.core.IAsyncJob
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.core.IStateGetter
+import org.swiften.redux.core.ISubscriberIDProvider
 
 /** Created by haipham on 2019/01/07 */
 /**
@@ -51,7 +52,7 @@ class SagaInput(
  * emitted values.
  * @param T The emission value type.
  */
-interface ISagaOutput<T> : IAsyncJob<T> where T : Any {
+interface ISagaOutput<T> : IAsyncJob<T>, ISubscriberIDProvider where T : Any {
   /** Trigger every time an [IReduxAction] arrives. */
   val onAction: IActionDispatcher
 

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -8,7 +8,6 @@ package org.swiften.redux.saga.common
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IAsyncJob
 import org.swiften.redux.core.IReduxAction
@@ -42,21 +41,10 @@ typealias ISagaEffectTransformer<R, R2> = (SagaEffect<R>) -> SagaEffect<R2>
  */
 class SagaInput(
   val scope: CoroutineScope = GlobalScope,
+  val monitor: ISagaMonitor,
   val lastState: IStateGetter<*>,
   val dispatch: IActionDispatcher
-) {
-  companion object {
-    /** Represents a [SagaInput] that does not have any meaningful functionalities. */
-    val EMPTY = this.withState({})
-
-    /**
-     * Creates a [SagaInput] that simply returns [state] when [SagaInput.lastState] is invoked.
-     * @param state See [SagaInput.lastState].
-     * @return A [SagaInput] instance.
-     */
-    fun withState(state: Any) = SagaInput(GlobalScope, { state }) { EmptyJob }
-  }
-}
+)
 
 /**
  * Stream values for a [ISagaEffect]. This stream has functional operators that can transform
@@ -210,30 +198,6 @@ interface ISagaOutput<T> : IAsyncJob<T> where T : Any {
  * @param R The result emission type.
  */
 abstract class SagaEffect<R> : ISagaEffect<R> where R : Any {
-  /**
-   * Call [ISagaEffect] with convenience parameters for testing.
-   * @param scope A [CoroutineScope] instance.
-   * @param state See [SagaInput.lastState].
-   * @param dispatch See [SagaInput.dispatch].
-   * @return An [ISagaOutput] instance.
-   */
-  fun invoke(scope: CoroutineScope, state: Any, dispatch: IActionDispatcher): ISagaOutput<R> {
-    return this.invoke(SagaInput(scope, { state }, dispatch))
-  }
-
-  /**
-   * Call [ISagaEffect] with convenience parameters for testing.
-   * @param state See [SagaInput.lastState].
-   * @return An [ISagaOutput] instance.
-   */
-  fun invoke(state: Any): ISagaOutput<R> = this.invoke(SagaInput.withState(state))
-
-  /**
-   * Call [ISagaEffect] with convenience parameters for testing.
-   * @return An [ISagaOutput] instance.
-   */
-  fun invoke(): ISagaOutput<R> = this.invoke(SagaInput.EMPTY)
-
   /**
    * Transform into another [SagaEffect] with [transformer].
    * @param R2 The emission type of the resulting [SagaEffect].

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
@@ -14,10 +14,10 @@ import java.util.concurrent.ConcurrentHashMap
 /** Monitors all [ISagaOutput] and calls [ISagaOutput.onAction] when an action arrives. */
 interface ISagaMonitor : IDispatcherProvider {
   /** Store [dispatch] with a unique [id]. */
-  fun set(id: String, dispatch: IActionDispatcher)
+  fun setOutputDispatcher(id: String, dispatch: IActionDispatcher)
 
   /** Remove the associated [IActionDispatcher] instance. */
-  fun remove(id: String)
+  fun removeOutputDispatcher(id: String)
 }
 
 /** Default implementation of [ISagaMonitor]. */
@@ -28,11 +28,11 @@ class SagaMonitor : ISagaMonitor {
     this@SagaMonitor.dispatchers.forEach { it.value(a) }; EmptyJob
   }
 
-  override fun set(id: String, dispatch: IActionDispatcher) {
+  override fun setOutputDispatcher(id: String, dispatch: IActionDispatcher) {
     this.dispatchers[id] = dispatch
   }
 
-  override fun remove(id: String) {
+  override fun removeOutputDispatcher(id: String) {
     this.dispatchers.remove(id)
   }
 }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 /** Created by viethai.pham on 2019/02/22 */
 /** Monitors all [ISagaOutput] and calls [ISagaOutput.onAction] when an action arrives. */
-interface ISagaMonitor {
+interface ISagaMonitor : IDispatcherProvider {
   /** Store [dispatch] with a unique [id]. */
   fun set(id: String, dispatch: IActionDispatcher)
 
@@ -21,7 +21,7 @@ interface ISagaMonitor {
 }
 
 /** Default implementation of [ISagaMonitor]. */
-class SagaMonitor : ISagaMonitor, IDispatcherProvider {
+class SagaMonitor : ISagaMonitor {
   private val dispatchers = ConcurrentHashMap<String, IActionDispatcher>()
 
   override val dispatch: IActionDispatcher = { a ->

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) haipham 2019. All rights reserved.
+ * Any attempt to reproduce this source code in any form shall be met with legal actions.
+ */
+
+package org.swiften.redux.saga.common
+
+import org.swiften.redux.core.EmptyJob
+import org.swiften.redux.core.IActionDispatcher
+import org.swiften.redux.core.IDispatcherProvider
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+/** Created by viethai.pham on 2019/02/22 */
+/** Monitors all [ISagaOutput] and calls [ISagaOutput.onAction] when an action arrives. */
+interface ISagaMonitor : IDispatcherProvider {
+  /** Store [dispatch] with a unique [id]. */
+  fun set(id: String, dispatch: IActionDispatcher)
+
+  /** Remove an [IActionDispatcher] with [id]. */
+  fun remove(id: String)
+}
+
+/** Default implementation of [ISagaMonitor]. */
+class SagaMonitor : ISagaMonitor {
+  private val lock by lazy { ReentrantReadWriteLock() }
+  private val dispatchers by lazy { hashMapOf<String, IActionDispatcher>() }
+
+  override val dispatch: IActionDispatcher = { a ->
+    this@SagaMonitor.lock.read { this@SagaMonitor.dispatchers.forEach { it.value(a) }; EmptyJob }
+  }
+
+  override fun set(id: String, dispatch: IActionDispatcher) {
+    this.lock.write { this.dispatchers[id] = dispatch }
+  }
+
+  override fun remove(id: String) {
+    this.lock.write { this.dispatchers.remove(id) }
+  }
+}

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
@@ -17,6 +17,9 @@ import kotlin.concurrent.write
 interface ISagaMonitor {
   /** Store [dispatch] with a unique [id]. */
   fun set(id: String, dispatch: IActionDispatcher)
+
+  /** Remove the associated [IActionDispatcher] instance. */
+  fun remove(id: String)
 }
 
 /** Default implementation of [ISagaMonitor]. */
@@ -32,7 +35,7 @@ class SagaMonitor : ISagaMonitor, IDispatcherProvider {
     this.lock.write { this.dispatchers[id] = dispatch }
   }
 
-  fun remove(id: String) {
+  override fun remove(id: String) {
     this.lock.write { this.dispatchers.remove(id) }
   }
 }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
@@ -14,16 +14,13 @@ import kotlin.concurrent.write
 
 /** Created by viethai.pham on 2019/02/22 */
 /** Monitors all [ISagaOutput] and calls [ISagaOutput.onAction] when an action arrives. */
-interface ISagaMonitor : IDispatcherProvider {
+interface ISagaMonitor {
   /** Store [dispatch] with a unique [id]. */
   fun set(id: String, dispatch: IActionDispatcher)
-
-  /** Remove an [IActionDispatcher] with [id]. */
-  fun remove(id: String)
 }
 
 /** Default implementation of [ISagaMonitor]. */
-class SagaMonitor : ISagaMonitor {
+class SagaMonitor : ISagaMonitor, IDispatcherProvider {
   private val lock by lazy { ReentrantReadWriteLock() }
   private val dispatchers by lazy { hashMapOf<String, IActionDispatcher>() }
 
@@ -35,7 +32,7 @@ class SagaMonitor : ISagaMonitor {
     this.lock.write { this.dispatchers[id] = dispatch }
   }
 
-  override fun remove(id: String) {
+  fun remove(id: String) {
     this.lock.write { this.dispatchers.remove(id) }
   }
 }

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/CommonSagaEffectTest.kt
@@ -130,12 +130,12 @@ abstract class CommonSagaEffectTest {
         dispatchers.forEach { it.value(action) }; EmptyJob
       }
 
-      override fun set(id: String, dispatch: IActionDispatcher) {
+      override fun setOutputDispatcher(id: String, dispatch: IActionDispatcher) {
         dispatchers[id] = dispatch
         setCount.incrementAndGet()
       }
 
-      override fun remove(id: String) {
+      override fun removeOutputDispatcher(id: String) {
         dispatchers.remove(id)
         removeCount.incrementAndGet()
       }

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
@@ -40,7 +40,7 @@ class SagaMiddlewareTest : BaseMiddlewareTest() {
     val monitor = SagaMonitor()
     val effects = outputs.map<ISagaOutput<Any>, ISagaEffect<Any>> { o -> { o } }
     val input = this.mockMiddlewareInput(0)
-    outputs.forEachIndexed { i, o -> monitor.set("$i", o.onAction) }
+    outputs.forEachIndexed { i, o -> monitor.setOutputDispatcher("$i", o.onAction) }
 
     val wrappedDispatch = createSagaMiddleware(EmptyCoroutineContext, monitor, effects)
       .invoke(input)(this.mockDispatchWrapper())

--- a/sample-android/sample-simple/src/test/java/org/swiften/redux/android/sample/ReduxSagaTest.kt
+++ b/sample-android/sample-simple/src/test/java/org/swiften/redux/android/sample/ReduxSagaTest.kt
@@ -12,6 +12,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IReduxAction
+import org.swiften.redux.saga.common.SagaInput
+import org.swiften.redux.saga.common.SagaMonitor
 
 /** Created by viethai.pham on 2019/02/20 */
 open class ReduxSagaTest {
@@ -34,7 +36,7 @@ class SearchSagaTest : ReduxSagaTest() {
     }
 
     val outputStream = Redux.Saga.searchSaga(api, debounce = 0)
-      .invoke(GlobalScope, state) { a -> dispatched.add(a); EmptyJob }
+      .invoke(SagaInput(GlobalScope, SagaMonitor(), {state}) { a -> dispatched.add(a); EmptyJob })
 
     outputStream.subscribe({})
 
@@ -68,7 +70,7 @@ class SearchSagaTest : ReduxSagaTest() {
     }
 
     val outputStream = Redux.Saga.searchSaga(api, debounce = 0)
-      .invoke(GlobalScope, state) { a -> dispatched.add(a); EmptyJob }
+      .invoke(SagaInput(GlobalScope, SagaMonitor(), {state}) { a -> dispatched.add(a); EmptyJob })
 
     outputStream.subscribe({})
 


### PR DESCRIPTION
Add **SagaMonitor** to keep track of **ISagaOutput.onAction** in order to call these functions when a new action arrives. This did not happen in previous implementation because saga outputs simply inherit **onAction** from parent.

So now it's possible to do:
```kotlin
takeLatest(Action::class, {
  when (it) {
    is Action.Init -> true
    is Action.Deinit -> false
    else -> null
  }
}) { init ->
  if (init) {
     takeLatest(Action::class, {
       when (it) {
         is Action.DoSomething -> it.value
         else -> null
       }
     }) { ... }
  } else {
     doNothing()
  }
}
```

Thus we can actually init/deinit streams with these changes.
