### PR TITLE
Allow afterPropInjectionEnds to access static prop

### DIFF
--- a/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
+++ b/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
@@ -8,6 +8,7 @@ package org.swiften.redux.android.ui.lifecycle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import org.swiften.redux.core.DefaultSubscriberIDProvider
 import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IDeinitializer
@@ -16,7 +17,6 @@ import org.swiften.redux.core.IReduxUnsubscriber
 import org.swiften.redux.core.IStateGetter
 import org.swiften.redux.core.ISubscriberIDProvider
 import org.swiften.redux.core.ReduxSubscription
-import org.swiften.redux.core.DefaultSubscriberIDProvider
 import org.swiften.redux.ui.IFullPropInjector
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
@@ -81,10 +81,11 @@ open class BaseLifecycleTest {
       State : Any,
       Action : Any {
       val lastState = this.lastState()
-      val subscription = ReduxSubscription(view.uniqueSubscriberID) { view.afterPropInjectionEnds() }
+      val sp = StaticProp(this as IFullPropInjector<LState>, outProp)
+      val subscription = ReduxSubscription(view.uniqueSubscriberID) { view.afterPropInjectionEnds(sp) }
       val state = mapper.mapState(lastState as LState, outProp)
       val action = mapper.mapAction(this.dispatch, outProp)
-      view.beforePropInjectionStarts(StaticProp(this as IFullPropInjector<LState>, outProp))
+      view.beforePropInjectionStarts(sp)
       view.reduxProp = ReduxProp(state, action)
       this.subscriptions[view.uniqueSubscriberID] = subscription
       return subscription

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapter.kt
@@ -193,9 +193,10 @@ fun <GState, LState, OutProp, VH, VHState, VHAction> IPropInjector<GState>.injec
        * [ReduxListAdapter.composite] in [RecyclerView.Adapter.onViewRecycled] to allow reuse.
        */
       val subscribeId = "$position"
-      val subscription = ReduxSubscription(subscribeId) { holder.afterPropInjectionEnds() }
+      val sp = this.staticProp
+      val subscription = ReduxSubscription(subscribeId) { holder.afterPropInjectionEnds(sp) }
       this.composite.add(subscription)
-      holder.beforePropInjectionStarts(this.staticProp)
+      holder.beforePropInjectionStarts(sp)
       holder.reduxProp = ReduxProp(this.getItem(position), this.reduxProp.action)
     }
 

--- a/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapterTest.kt
+++ b/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/DiffedAdapterTest.kt
@@ -45,7 +45,7 @@ class DiffedAdapterTest : BaseLifecycleTest() {
       this.beforeInjection.incrementAndGet()
     }
 
-    override fun afterPropInjectionEnds() {
+    override fun afterPropInjectionEnds(sp: StaticProp<Int, Unit>) {
       this.afterInjection.incrementAndGet()
     }
   }

--- a/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
+++ b/android/android-recyclerview/src/test/java/org/swiften/redux/android/ui/recyclerview/RecycleAdapterTest.kt
@@ -19,9 +19,9 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.swiften.redux.android.ui.lifecycle.BaseLifecycleTest
+import org.swiften.redux.core.DefaultSubscriberIDProvider
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.ISubscriberIDProvider
-import org.swiften.redux.core.DefaultSubscriberIDProvider
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
 import org.swiften.redux.ui.IPropMapper
@@ -52,7 +52,7 @@ class RecycleAdapterTest : BaseLifecycleTest() {
       this.beforeInjection.incrementAndGet()
     }
 
-    override fun afterPropInjectionEnds() {
+    override fun afterPropInjectionEnds(sp: StaticProp<Int, PositionProp<Unit>>) {
       this.afterInjection.incrementAndGet()
     }
   }

--- a/android/android-ui/src/main/java/org/swiften/redux/android/ui/AndroidPropInjector.kt
+++ b/android/android-ui/src/main/java/org/swiften/redux/android/ui/AndroidPropInjector.kt
@@ -51,8 +51,8 @@ class AndroidPropInjector<GState>(
         this@AndroidPropInjector.runner { view.beforePropInjectionStarts(sp) }
       }
 
-      override fun afterPropInjectionEnds() {
-        this@AndroidPropInjector.runner { view.afterPropInjectionEnds() }
+      override fun afterPropInjectionEnds(sp: StaticProp<LState, OutProp>) {
+        this@AndroidPropInjector.runner { view.afterPropInjectionEnds(sp) }
       }
 
       override fun toString() = view.toString()

--- a/android/android-ui/src/test/java/org/swiften/redux/android/ui/AndroidInjectorTest.kt
+++ b/android/android-ui/src/test/java/org/swiften/redux/android/ui/AndroidInjectorTest.kt
@@ -14,9 +14,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.swiften.redux.android.util.AndroidUtil
+import org.swiften.redux.core.DefaultSubscriberIDProvider
 import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.core.ISubscriberIDProvider
-import org.swiften.redux.core.DefaultSubscriberIDProvider
 import org.swiften.redux.ui.IFullPropInjector
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
@@ -68,7 +68,7 @@ class AndroidInjectorTest : PropInjectorTest() {
       this.beforeInjectionCount.incrementAndGet()
     }
 
-    override fun afterPropInjectionEnds() {
+    override fun afterPropInjectionEnds(sp: StaticProp<S, Unit>) {
       this.afterInjectionCount.incrementAndGet()
       this.propInitialized.set(false)
     }

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Container.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Container.kt
@@ -22,8 +22,9 @@ interface IPropLifecycleOwner<LState, OutProp> where LState : Any {
 
   /**
    * This is called after [IReduxSubscription.unsubscribe] is called.
+   * @param sp A [StaticProp] instance.
    */
-  fun afterPropInjectionEnds()
+  fun afterPropInjectionEnds(sp: StaticProp<LState, OutProp>)
 }
 
 /**
@@ -34,7 +35,7 @@ interface IPropLifecycleOwner<LState, OutProp> where LState : Any {
  */
 class NoopPropLifecycleOwner<LState, OutProp> : IPropLifecycleOwner<LState, OutProp> where LState : Any {
   override fun beforePropInjectionStarts(sp: StaticProp<LState, OutProp>) {}
-  override fun afterPropInjectionEnds() {}
+  override fun afterPropInjectionEnds(sp: StaticProp<LState, OutProp>) {}
 }
 
 /**

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
@@ -100,7 +100,8 @@ open class PropInjector<GState : Any> protected constructor(
 
     /** If [view] has received an injection before, unsubscribe from that. */
     this.unsubscribe(subscriberId)
-    view.beforePropInjectionStarts(StaticProp(this as IPropInjector<LState>, outProp))
+    val staticProp = StaticProp(this as IPropInjector<LState>, outProp)
+    view.beforePropInjectionStarts(staticProp)
     val lock = ReentrantReadWriteLock()
     var previousState: State? = null
 
@@ -130,7 +131,7 @@ open class PropInjector<GState : Any> protected constructor(
     /** Wrap a [ReduxSubscription] to perform [IPropLifecycleOwner.afterPropInjectionEnds] */
     val wrappedSubscription = ReduxSubscription(subscription.uniqueSubscriberID) {
       subscription.unsubscribe()
-      view.afterPropInjectionEnds()
+      view.afterPropInjectionEnds(staticProp)
     }
 
     this.subscriptions[subscriberId] = wrappedSubscription

--- a/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
+++ b/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
+import org.swiften.redux.core.DefaultSubscriberIDProvider
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxStore
@@ -16,7 +17,6 @@ import org.swiften.redux.core.IReduxSubscriber
 import org.swiften.redux.core.ISubscriberIDProvider
 import org.swiften.redux.core.ReduxSubscription
 import org.swiften.redux.core.ThreadSafeStore
-import org.swiften.redux.core.DefaultSubscriberIDProvider
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -66,7 +66,7 @@ open class PropInjectorTest {
       this.beforeInjectionCount.incrementAndGet()
     }
 
-    override fun afterPropInjectionEnds() {
+    override fun afterPropInjectionEnds(sp: StaticProp<S, Unit>) {
       this.afterInjectionCount.incrementAndGet()
       this.propInitialized.set(false)
     }

--- a/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/business1/ParentFragment1.kt
+++ b/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/business1/ParentFragment1.kt
@@ -17,7 +17,6 @@ import kotlinx.android.synthetic.main.parent_1.search_view
 import org.swiften.redux.android.dagger.DependencyLevel1
 import org.swiften.redux.android.dagger.R
 import org.swiften.redux.android.dagger.Redux
-import org.swiften.redux.android.ui.lifecycle.injectLifecycle
 import org.swiften.redux.core.DefaultSubscriberIDProvider
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.ISubscriberIDProvider
@@ -74,10 +73,11 @@ class ParentFragment1 : Fragment(),
   override fun beforePropInjectionStarts(sp: StaticProp<Redux.State, DependencyLevel1>) {
     this.nav1.setOnClickListener { this@ParentFragment1.reduxProp.action.goToScreen2() }
     this.nav2.setOnClickListener { this@ParentFragment1.reduxProp.action.goToScreen3() }
-    sp.injector.injectLifecycle(Unit, this.search_view, SearchView1)
+    sp.injector.inject(Unit, this.search_view, SearchView1)
   }
 
-  override fun afterPropInjectionEnds() {
+  override fun afterPropInjectionEnds(sp: StaticProp<Redux.State, DependencyLevel1>) {
     this.reduxProp.action.deinitializeBusiness1()
+    sp.injector.unsubscribe(this.search_view.uniqueSubscriberID)
   }
 }


### PR DESCRIPTION
**afterPropInjectionEnds** now has access to **StaticProp**. This allows us to call **injector.unsubscribe** for injection targets that are not lifecycle owner (e.g. custom Views). For example:

```kotlin
override fun beforePropInjectionStarts(sp: StaticProp<Redux.State, DependencyLevel1>) {
  sp.injector.inject(Unit, this.search_view, SearchView1)
}

override fun afterPropInjectionEnds(sp: StaticProp<Redux.State, DependencyLevel1>) {
  sp.injector.unsubscribe(this.search_view.uniqueSubscriberID)
}
```
