### PR TITLE
Nested router and vetoable router

### DIFF
--- a/android/android-router/src/main/java/org/swiften/redux/android/router/SingleActivityRouter.kt
+++ b/android/android-router/src/main/java/org/swiften/redux/android/router/SingleActivityRouter.kt
@@ -59,7 +59,7 @@ internal class SingleActivityRouter<AT, Screen>(
   init { this.application.registerActivityLifecycleCallbacks(this.callbacks) }
 
   override val deinitialize: IDeinitializer get() = {
-    this.application.unregisterActivityLifecycleCallbacks(this.callbacks)
+    this.runner.invoke { this.application.unregisterActivityLifecycleCallbacks(this.callbacks) }
   }
 
   override fun navigate(screen: Screen) {
@@ -80,8 +80,9 @@ inline fun <reified AT, Screen> createSingleActivityRouter(
   application: Application,
   runner: AndroidUtil.IMainThreadRunner = AndroidUtil.MainThreadRunner,
   noinline navigate: (AT, Screen) -> Unit
-): IRouter<Screen> where AT : AppCompatActivity, Screen : IRouterScreen =
-  SingleActivityRouter(AT::class.java, application, runner, navigate)
+): IRouter<Screen> where AT : AppCompatActivity, Screen : IRouterScreen {
+  return SingleActivityRouter(AT::class.java, application, runner, navigate)
+}
 
 /**
  * Create a [SingleActivityRouter] with the default [AndroidUtil.MainThreadRunner].
@@ -94,5 +95,6 @@ inline fun <reified AT, Screen> createSingleActivityRouter(
 inline fun <reified AT, Screen> createSingleActivityRouter(
   application: Application,
   noinline navigate: (AT, Screen) -> Unit
-): IRouter<Screen> where AT : AppCompatActivity, Screen : IRouterScreen =
-  SingleActivityRouter(AT::class.java, application, AndroidUtil.MainThreadRunner, navigate)
+): IRouter<Screen> where AT : AppCompatActivity, Screen : IRouterScreen {
+  return SingleActivityRouter(AT::class.java, application, AndroidUtil.MainThreadRunner, navigate)
+}

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/NestedRouter.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/NestedRouter.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) haipham 2019. All rights reserved.
+ * Any attempt to reproduce this source code in any form shall be met with legal actions.
+ */
+
+package org.swiften.redux.core
+
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/** Created by viethai.pham on 2019/02/25 */
+/**
+ * [IRouter] implementation that holds on to a [List] of [IVetoableRouter], each of which will
+ * call [IVetoableRouter.navigate] to check if it can perform a successful navigation. If not, we
+ * move on to the next [IVetoableRouter] until the end.
+ * @param navigator The navigation function that will be called before we touch [subRouters].
+ */
+class NestedRouter internal constructor (private val navigator: (IRouterScreen) -> Boolean) : IRouter<IRouterScreen> {
+  sealed class Screen : IRouterScreen {
+    data class RegisterSubRouter(val subRouter: IVetoableRouter<IRouterScreen>) : Screen()
+    data class UnregisterSubRouter(val subRouter: IVetoableRouter<IRouterScreen>) : Screen()
+  }
+
+  private val subRouters = mutableSetOf<IVetoableRouter<IRouterScreen>>()
+
+  override val deinitialize: IDeinitializer get() = {
+    this@NestedRouter.subRouters.clear()
+  }
+
+  override fun navigate(screen: IRouterScreen) {
+    if (when (screen) {
+        is Screen.RegisterSubRouter -> {
+          this.subRouters.add(screen.subRouter)
+          true
+        }
+
+        is Screen.UnregisterSubRouter -> {
+          this.subRouters.remove(screen.subRouter)
+          true
+        }
+
+        else -> false
+    }) {
+      return
+    }
+
+    if (this.navigator(screen)) return
+    val subRouterSize = this.subRouters.size
+
+    if (subRouterSize > 0) {
+      for (subRouter in this.subRouters) {
+        if (subRouter.navigate(screen)) {
+          return
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Create an [IRouter] instance that provides locking mechanisms for an internal [NestedRouter].
+ * @param navigator See [NestedRouter.navigator].
+ * @return An [IRouter] instance.
+ */
+fun createNestedRouter(navigator: (IRouterScreen) -> Boolean) : IRouter<IRouterScreen> {
+  return object : IRouter<IRouterScreen> {
+    private val lock = ReentrantLock()
+    private val router = NestedRouter(navigator)
+
+    override fun navigate(screen: IRouterScreen) {
+      this.lock.withLock { this.router.navigate(screen) }
+    }
+
+    override val deinitialize: IDeinitializer get() = {
+      this.lock.withLock { this.router.deinitialize() }
+    }
+  }
+}

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Router.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Router.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) haipham 2019. All rights reserved.
+ * Any attempt to reproduce this source code in any form shall be met with legal actions.
+ */
+
+package org.swiften.redux.core
+
+/** Created by viethai.pham on 2019/02/25 */
+/**
+ * Represents a screen that also implements [IReduxAction], so that views can simply dispatch an
+ * [IRouterScreen] to navigate to the associated screen.
+ */
+interface IRouterScreen : IReduxAction
+
+/**
+ * Abstract the necessary work to navigate from one [Screen] to another.
+ * @param Screen The app [IRouterScreen] type.
+ */
+interface IRouter<in Screen> : IDeinitializerProvider where Screen : IRouterScreen {
+  /**
+   * Navigate to an [IRouterScreen]. How this is done is left to the app's specific implementation.
+   * @param screen The incoming [Screen] instance.
+   */
+  fun navigate(screen: Screen)
+}
+
+/**
+ * Represents a router whose [navigate] returns a [Boolean] indicating whether a successful
+ * navigation happened. This can be used in a main-sub router set-up whereby there is a [Collection]
+ * of [IVetoableRouter], and every time a [Screen] arrives, the first [IVetoableRouter] that returns
+ * true for [navigate] performs the navigation.
+ * @param Screen The app [IRouterScreen] type.
+ */
+interface IVetoableRouter<in Screen> : IDeinitializerProvider where Screen : IRouterScreen {
+  /**
+   * Navigate to an [IRouterScreen]. How this is done is left to the app's specific implementation.
+   * @param screen The incoming [Screen] instance.
+   * @return A [Boolean] value.
+   */
+  fun navigate(screen: Screen): Boolean
+}

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Router.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Router.kt
@@ -31,7 +31,7 @@ interface IRouter<in Screen> : IDeinitializerProvider where Screen : IRouterScre
  * true for [navigate] performs the navigation.
  * @param Screen The app [IRouterScreen] type.
  */
-interface IVetoableRouter<in Screen> : IDeinitializerProvider where Screen : IRouterScreen {
+interface IVetoableRouter<in Screen> where Screen : IRouterScreen {
   /**
    * Navigate to an [IRouterScreen]. How this is done is left to the app's specific implementation.
    * @param screen The incoming [Screen] instance.

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
@@ -9,32 +9,13 @@ import kotlin.reflect.KClass
 
 /** Created by haipham on 2018/12/16 */
 /**
- * Represents a screen that also implements [IReduxAction], so that views can simply dispatch an
- * [IRouterScreen] to navigate to the associated screen.
- */
-interface IRouterScreen : IReduxAction
-
-/**
- * Abstract the necessary work to navigate from one [Screen] to another.
- * @param Screen The app [IRouterScreen] type.
- */
-interface IRouter<Screen> : IDeinitializerProvider where Screen : IRouterScreen {
-  /**
-   * Navigate to an [IRouterScreen]. How this is done is left to the app's specific
-   * implementation.
-   * @param screen The incoming [Screen] instance.
-   */
-  fun navigate(screen: Screen)
-}
-
-/**
  * [IMiddleware] implementation for [IRouter] middleware.
  * @param Screen The app [IRouterScreen] type.
  * @param cls The [Class] of the [Screen] type to check type for [IReduxAction].
  * @param router An [IRouter] instance.
  */
 @PublishedApi
-internal class RouterMiddleware<Screen>(
+internal class RouterMiddleware<out Screen>(
   private val cls: Class<Screen>,
   private val router: IRouter<Screen>
 ) : IMiddleware<Any> where Screen : IRouterScreen {
@@ -71,6 +52,8 @@ internal class RouterMiddleware<Screen>(
  * @param router See [RouterMiddleware.router].
  * @return A [RouterMiddleware] instance.
  */
-inline fun <reified Screen> createRouterMiddleware(router: IRouter<Screen>):
-  IMiddleware<Any> where Screen : IRouterScreen =
-  RouterMiddleware(Screen::class, router)
+inline fun <reified Screen> createRouterMiddleware(
+  router: IRouter<Screen>
+): IMiddleware<Any> where Screen : IRouterScreen {
+  return RouterMiddleware(Screen::class, router)
+}

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/NestedRouterTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/NestedRouterTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) haipham 2019. All rights reserved.
+ * Any attempt to reproduce this source code in any form shall be met with legal actions.
+ */
+
+package org.swiften.redux.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Created by viethai.pham on 2019/02/26 */
+class NestedRouterTest {
+  class SubRouter : IVetoableRouter<IRouterScreen> {
+    val navigationCount = AtomicInteger()
+
+    override fun navigate(screen: IRouterScreen): Boolean {
+      this.navigationCount.incrementAndGet()
+      return true
+    }
+  }
+
+  class Screen(@Suppress("unused") val path: String) : IRouterScreen
+
+  private val iteration = 1000
+
+  @Test
+  fun `Sending register or unregister actions should add or remove sub-router`() {
+    // Setup
+    val router = createNestedRouter { false }
+    val subRouter = SubRouter()
+
+    // When
+    val batch1 = (0 until this.iteration / 2).map {
+      GlobalScope.launch {
+        router.navigate(NestedRouter.Screen.RegisterSubRouter(subRouter))
+      }
+    }
+
+    val batch2 = (0 until this.iteration / 2).map {
+      GlobalScope.launch(Dispatchers.IO) {
+        router.navigate(NestedRouter.Screen.RegisterSubRouter(subRouter))
+      }
+    }
+
+    runBlocking {
+      batch1.forEach { it.join() }
+      batch2.forEach { it.join() }
+
+      val batch3 = (0 until this@NestedRouterTest.iteration).map { i ->
+        GlobalScope.launch(Dispatchers.IO) { router.navigate(Screen("$i")) }
+      }
+
+      batch3.forEach { it.join() }
+      router.navigate(NestedRouter.Screen.UnregisterSubRouter(subRouter))
+      repeat(this@NestedRouterTest.iteration) { router.navigate(Screen("Ignored")) }
+
+      // Then
+      assertEquals(subRouter.navigationCount.get(), this@NestedRouterTest.iteration)
+    }
+  }
+
+  @Test
+  fun `Should use default navigation before going to sub-router`() {
+    // Setup
+    val defaultNavigationCount = AtomicInteger()
+    val router = createNestedRouter { defaultNavigationCount.incrementAndGet(); true }
+    val subRouter = SubRouter()
+    router.navigate(NestedRouter.Screen.RegisterSubRouter(subRouter))
+
+    val batch = (0 until this@NestedRouterTest.iteration).map { i ->
+      GlobalScope.launch(Dispatchers.IO) { router.navigate(Screen("$i")) }
+    }
+
+    // When
+    runBlocking {
+      batch.forEach { it.join() }
+
+      // Then
+      assertEquals(defaultNavigationCount.get(), this@NestedRouterTest.iteration)
+      assertEquals(subRouter.navigationCount.get(), 0)
+    }
+  }
+}


### PR DESCRIPTION
Add a **NestedRouter** implementation that simplifies routing/navigation by allowing any object to register itself as a sub-router. Every time a screen arrives, the sub-router set is iterated through to see which sub-router can successfully perform the navigation (in this case, a Boolean flag is returned by **IVetoableRouter.navigate** to indicate successful navigation).

Sub-routers can register/unregister themselves with **NestedRouter.Screen.RegisterSubRouter/UnregisterSubRouter** actions:

```kotlin
class Fragment1 : Fragment(), IVetoableRouter<IRouterScreen> {
  fun setUp() {
    this.reduxProp.action.registerSubRouter(this)
  }

  fun tearDown() {
    this.reduxProp.action.unregisterSubRouter(this)
  }

  override fun navigate(screen: IRouterScreen): Boolean {
    // Returning false here will effectively skip this sub-router every time.
    return false
  }
}
```