### PR TITLE
move create* top-level functions to companion object namespace

### DIFF
--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncMiddleware.kt
@@ -16,7 +16,27 @@ import kotlin.coroutines.CoroutineContext
  * [IMiddleware] implementation that calls [DispatchWrapper.dispatch] on another thread.
  * @param context A [CoroutineContext] instance.
  */
-internal class AsyncMiddleware(private val context: CoroutineContext) : IMiddleware<Any> {
+class AsyncMiddleware private constructor (private val context: CoroutineContext) : IMiddleware<Any> {
+  companion object {
+    /**
+     * Create a [AsyncMiddleware] with [context].
+     * @param context See [AsyncMiddleware.context].
+     * @return An [AsyncMiddleware] instance.
+     */
+    internal fun create(context: CoroutineContext): IMiddleware<Any> {
+      return AsyncMiddleware(context)
+    }
+
+    /**
+     * Create a [AsyncMiddleware] with a default [CoroutineContext]. This is made public so that
+     * users of this [AsyncMiddleware] cannot share its [CoroutineContext] with other users.
+     * @return An [AsyncMiddleware] instance.
+     */
+    fun create(): IMiddleware<Any> {
+      return this.create(SupervisorJob())
+    }
+  }
+
   override fun invoke(p1: MiddlewareInput<Any>): DispatchMapper {
     return { wrapper ->
       val context = this@AsyncMiddleware.context
@@ -30,22 +50,4 @@ internal class AsyncMiddleware(private val context: CoroutineContext) : IMiddlew
       }
     }
   }
-}
-
-/**
- * Create a [AsyncMiddleware] with [context].
- * @param context See [AsyncMiddleware.context].
- * @return An [AsyncMiddleware] instance.
- */
-internal fun createAsyncMiddleware(context: CoroutineContext): IMiddleware<Any> {
-  return AsyncMiddleware(context)
-}
-
-/**
- * Create a [AsyncMiddleware] with a default [CoroutineContext]. This is made public so that users
- * of this [AsyncMiddleware] cannot share its [CoroutineContext] with other users.
- * @return An [AsyncMiddleware] instance.
- */
-fun createAsyncMiddleware(): IMiddleware<Any> {
-  return createAsyncMiddleware(SupervisorJob())
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
@@ -14,11 +14,24 @@ import kotlin.reflect.KClass
  * @param cls The [Class] of the [Screen] type to check type for [IReduxAction].
  * @param router An [IRouter] instance.
  */
-@PublishedApi
-internal class RouterMiddleware<out Screen>(
+class RouterMiddleware<out Screen> private constructor (
   private val cls: Class<Screen>,
   private val router: IRouter<Screen>
 ) : IMiddleware<Any> where Screen : IRouterScreen {
+  companion object {
+    /**
+     * Create a [RouterMiddleware] with [router].
+     * @param Screen The app [IRouterScreen] type.
+     * @param router See [RouterMiddleware.router].
+     * @return A [RouterMiddleware] instance.
+     */
+    inline fun <reified Screen> create(
+      router: IRouter<Screen>
+    ): IMiddleware<Any> where Screen : IRouterScreen {
+      return RouterMiddleware(Screen::class, router)
+    }
+  }
+
   constructor(cls: KClass<Screen>, router: IRouter<Screen>) : this(cls.java, router)
 
   override fun invoke(p1: MiddlewareInput<Any>): DispatchMapper {
@@ -44,16 +57,4 @@ internal class RouterMiddleware<out Screen>(
       }
     }
   }
-}
-
-/**
- * Create a [RouterMiddleware] with [router].
- * @param Screen The app [IRouterScreen] type.
- * @param router See [RouterMiddleware.router].
- * @return A [RouterMiddleware] instance.
- */
-inline fun <reified Screen> createRouterMiddleware(
-  router: IRouter<Screen>
-): IMiddleware<Any> where Screen : IRouterScreen {
-  return RouterMiddleware(Screen::class, router)
 }

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncJobTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncJobTest.kt
@@ -22,9 +22,9 @@ class AsyncJobTest {
     class Action(val value: Int) : IReduxAction
 
     val store = applyMiddlewares<Int>(
-      createAsyncMiddleware(),
-      createAsyncMiddleware(),
-      createAsyncMiddleware()
+      AsyncMiddleware.create(),
+      AsyncMiddleware.create(),
+      AsyncMiddleware.create()
     )(FinalStore(-1) { s, a -> when (a) {
       is Action -> a.value
       else -> s

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncMiddlewareTest.kt
@@ -20,7 +20,7 @@ class AsyncMiddlewareTest : BaseMiddlewareTest() {
     // Setup
     val dispatched = AtomicInteger(0)
     val job = Job()
-    val middleware = createAsyncMiddleware(job)
+    val middleware = AsyncMiddleware.create(job)
     val dispatch: IActionDispatcher = { dispatched.incrementAndGet(); EmptyJob }
     val dispatchWrapper = this.mockDispatchWrapper(dispatch)
     val input = mockMiddlewareInput(0)

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncStoreTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncStoreTest.kt
@@ -8,6 +8,6 @@ package org.swiften.redux.core
 /** Created by haipham on 2018/01/14 */
 class AsyncStoreTest : BaseStoreTest() {
   override fun createStore(): IReduxStore<Int> {
-    return applyMiddlewares<Int>(createAsyncMiddleware())(ThreadSafeStore(0, this.reducer()))
+    return applyMiddlewares<Int>(AsyncMiddleware.create())(ThreadSafeStore(0, this.reducer()))
   }
 }

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/RouterMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/RouterMiddlewareTest.kt
@@ -37,7 +37,7 @@ class RouterMiddlewareTest : BaseMiddlewareTest() {
     // Setup
     val store = ThreadSafeStore(0) { a, _ -> a }
     val router = Router()
-    val wrappedStore = applyMiddlewares<Int>(createRouterMiddleware(router))(store)
+    val wrappedStore = applyMiddlewares<Int>(RouterMiddleware.create(router))(store)
 
     // When
     wrappedStore.dispatch(DefaultReduxAction.Dummy)
@@ -59,7 +59,7 @@ class RouterMiddlewareTest : BaseMiddlewareTest() {
     val router = Router()
 
     val wrappedStore = applyMiddlewares<Int>(
-      createRouterMiddleware(router)
+      RouterMiddleware.create(router)
     )(DefaultActionStore(0) { a, _ -> a })
 
     // When

--- a/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
+++ b/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.swiften.redux.core.AsyncMiddleware
 import org.swiften.redux.core.DefaultReduxAction
 import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.FinalStore
@@ -30,17 +31,16 @@ import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxActionWithKey
 import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.core.applyMiddlewares
-import org.swiften.redux.core.createAsyncMiddleware
 import org.swiften.redux.saga.common.CommonSagaEffectTest
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaMonitor
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
+import org.swiften.redux.saga.common.SagaMiddleware
 import org.swiften.redux.saga.common.SagaMonitor
 import org.swiften.redux.saga.common.TakeEffect
 import org.swiften.redux.saga.common.castValue
 import org.swiften.redux.saga.common.catchError
-import org.swiften.redux.saga.common.createSagaMiddleware
 import org.swiften.redux.saga.common.delayUpstreamValue
 import org.swiften.redux.saga.common.doOnValue
 import org.swiften.redux.saga.common.filter
@@ -223,11 +223,11 @@ class SagaEffectTest : CommonSagaEffectTest() {
     }
 
     store = applyMiddlewares<State>(
-      createAsyncMiddleware(),
-      createAsyncMiddleware(),
-      createSagaMiddleware(arrayListOf(takeEffect)),
-      createAsyncMiddleware(),
-      createAsyncMiddleware()
+      AsyncMiddleware.create(),
+      AsyncMiddleware.create(),
+      SagaMiddleware.create(arrayListOf(takeEffect)),
+      AsyncMiddleware.create(),
+      AsyncMiddleware.create()
     )(FinalStore(State(), enhancedReducer))
 
     // When

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
@@ -42,7 +42,7 @@ class SagaMiddlewareTest : BaseMiddlewareTest() {
     val input = this.mockMiddlewareInput(0)
     outputs.forEachIndexed { i, o -> monitor.addOutputDispatcher("$i", o.onAction) }
 
-    val wrappedDispatch = createSagaMiddleware(EmptyCoroutineContext, monitor, effects)
+    val wrappedDispatch = SagaMiddleware.create(EmptyCoroutineContext, monitor, effects)
       .invoke(input)(this.mockDispatchWrapper())
       .dispatch
 

--- a/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/MainApplication.kt
+++ b/sample-android/sample-dagger/src/main/java/org/swiften/redux/android/dagger/MainApplication.kt
@@ -9,11 +9,11 @@ import android.app.Application
 import com.squareup.leakcanary.LeakCanary
 import org.swiften.redux.android.ui.AndroidPropInjector
 import org.swiften.redux.android.ui.lifecycle.injectActivitySerializable
+import org.swiften.redux.core.AsyncMiddleware
 import org.swiften.redux.core.FinalStore
+import org.swiften.redux.core.RouterMiddleware
 import org.swiften.redux.core.applyMiddlewares
-import org.swiften.redux.core.createAsyncMiddleware
-import org.swiften.redux.core.createRouterMiddleware
-import org.swiften.redux.saga.common.createSagaMiddleware
+import org.swiften.redux.saga.common.SagaMiddleware
 
 /** Created by haipham on 26/1/19 */
 class MainApplication : Application() {
@@ -28,9 +28,9 @@ class MainApplication : Application() {
       .build()
 
     val store = applyMiddlewares<Redux.State>(
-      createAsyncMiddleware(),
-      createRouterMiddleware(Router(this)),
-      createSagaMiddleware(Redux.Saga.allSagas(component))
+      AsyncMiddleware.create(),
+      RouterMiddleware.create(Router(this)),
+      SagaMiddleware.create(Redux.Saga.allSagas(component))
     )(FinalStore(Redux.State(), Redux.Reducer))
 
     val injector = AndroidPropInjector(store)

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainApplication.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainApplication.kt
@@ -12,10 +12,10 @@ import org.swiften.redux.android.sample.Redux.State
 import org.swiften.redux.android.ui.AndroidPropInjector
 import org.swiften.redux.android.ui.lifecycle.injectActivitySerializable
 import org.swiften.redux.android.ui.lifecycle.injectLifecycle
+import org.swiften.redux.core.AsyncMiddleware
 import org.swiften.redux.core.FinalStore
 import org.swiften.redux.core.applyMiddlewares
-import org.swiften.redux.core.createAsyncMiddleware
-import org.swiften.redux.saga.common.createSagaMiddleware
+import org.swiften.redux.saga.common.SagaMiddleware
 
 /** Created by haipham on 26/1/19 */
 class MainApplication : Application() {
@@ -27,9 +27,9 @@ class MainApplication : Application() {
     val repository = Repository(Klaxon(), api)
 
     val store = applyMiddlewares<Redux.State>(
-      createAsyncMiddleware(),
-      createSagaMiddleware(Redux.Saga.allSagas(repository)),
-      createAsyncMiddleware()
+      AsyncMiddleware.create(),
+      SagaMiddleware.create(Redux.Saga.allSagas(repository)),
+      AsyncMiddleware.create()
     )(FinalStore(State(), Redux.Reducer))
 
     val injector = AndroidPropInjector(store)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenApplication.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenApplication.kt
@@ -15,11 +15,11 @@ import com.squareup.picasso.Picasso
 import org.swiften.redux.android.ui.AndroidPropInjector
 import org.swiften.redux.android.ui.lifecycle.injectActivityParcelable
 import org.swiften.redux.android.ui.lifecycle.injectLifecycle
+import org.swiften.redux.core.AsyncMiddleware
 import org.swiften.redux.core.FinalStore
+import org.swiften.redux.core.RouterMiddleware
 import org.swiften.redux.core.applyMiddlewares
-import org.swiften.redux.core.createAsyncMiddleware
-import org.swiften.redux.core.createRouterMiddleware
-import org.swiften.redux.saga.common.createSagaMiddleware
+import org.swiften.redux.saga.common.SagaMiddleware
 import org.swiften.redux.thunk.createThunkMiddleware
 
 /** Created by haipham on 2019/01/17 */
@@ -34,9 +34,9 @@ class GardenApplication : Application() {
     }
 
     val store = applyMiddlewares<Redux.State>(
-      createAsyncMiddleware(),
-      createRouterMiddleware(Router(this)),
-      createSagaMiddleware(
+      AsyncMiddleware.create(),
+      RouterMiddleware.create(Router(this)),
+      SagaMiddleware.create(
         arrayListOf(
           arrayListOf(Redux.Saga.CoreSaga.watchNetworkConnectivity(this)),
           Redux.Saga.GardenPlantingSaga.allSagas(InjectorUtils.getGardenPlantingRepository(this)),


### PR DESCRIPTION
New methods to be called:
- **createAsyncMiddleware** -> **AsyncMiddleware.create**.
- **createRouterMiddleware** -> **RouterMiddleware.create**.
- **createSagaMiddleware** -> **SagaMiddleware.create**.