### PR TITLE
Add firstTime flag to ReduxProp

### DIFF
--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
@@ -114,7 +114,7 @@ open class PropInjector<GState : Any> protected constructor(
 
         if (next != prev) {
           val action = mapper.mapAction(this@PropInjector.dispatch, outProp)
-          view.reduxProp = ReduxProp(next, action)
+          view.reduxProp = ReduxProp(prev == null, next, action)
         }
       }
     }

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
@@ -12,6 +12,7 @@ package org.swiften.redux.ui
  * @param Action Action type that handles view interactions.
  */
 interface IVariableProp<out State, out Action> where State : Any, Action : Any {
+  val firstTime: Boolean
   val state: State
   val action: Action
 }
@@ -30,10 +31,12 @@ data class StaticProp<LState, OutProp>(
  * Container for [state] and [action].
  * @param State See [IVariableProp.state].
  * @param Action See [IVariableProp.action].
+ * @param firstTime Whether this [ReduxProp] is the first one to be injected.
  * @param state A [State] instance.
  * @param action An [Action] instance.
  */
 data class ReduxProp<State, Action>(
+  override val firstTime: Boolean,
   override val state: State,
   override val action: Action
 ) : IVariableProp<State, Action> where State : Any, Action : Any

--- a/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
+++ b/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
@@ -6,6 +6,8 @@
 package org.swiften.redux.ui
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.swiften.redux.core.DefaultUniqueIDProvider
@@ -90,6 +92,21 @@ open class PropInjectorTest {
 
   open fun createInjector(store: IReduxStore<S>): IFullPropInjector<S> {
     return TestInjector(store)
+  }
+
+  @Test
+  fun `Injection props multiple times should update firstTime flag`() {
+    // Setup
+    val injector = this.createInjector(this.store)
+    val view = View()
+
+    // When && Then
+    injector.inject(Unit, view, this.mapper)
+    assertTrue(view.reduxProp.firstTime)
+
+    // When && Then
+    this.store.dispatch(Action.SetQuery("1"))
+    assertFalse(view.reduxProp.firstTime)
   }
 
   @Test


### PR DESCRIPTION
Add **firstTime** to **ReduxProp** to allow one-time initialization logic using Redux prop:

```kotlin
override var reduxProp by ObservableReduxProp<State, Action> { _, next ->
  if (next.firstTime) {
    next.action.initialize()
  }
}
```