### PR TITLE
Add NoopActionDispatcher

### DIFF
--- a/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
+++ b/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
@@ -9,12 +9,12 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import org.swiften.redux.core.DefaultUniqueIDProvider
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IReduxSubscription
 import org.swiften.redux.core.IReduxUnsubscriber
 import org.swiften.redux.core.IStateGetter
 import org.swiften.redux.core.IUniqueIDProvider
+import org.swiften.redux.core.NoopActionDispatcher
 import org.swiften.redux.core.ReduxSubscription
 import org.swiften.redux.ui.IFullPropInjector
 import org.swiften.redux.ui.IPropContainer
@@ -90,7 +90,7 @@ open class BaseLifecycleTest {
       return subscription
     }
 
-    override val dispatch: IActionDispatcher = { EmptyJob }
+    override val dispatch: IActionDispatcher = NoopActionDispatcher
     override fun deinitialize() {}
   }
 }

--- a/android/android-livedata-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/livedata/TakeEveryEffect.kt
+++ b/android/android-livedata-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/livedata/TakeEveryEffect.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.Observer
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
@@ -40,6 +39,6 @@ internal class TakeEveryEffect<R>(private val creator: () -> LiveData<R>) : Saga
       .toFlowable(BackpressureStrategy.BUFFER)
       .serialize()
 
-    return SagaOutput(p1.scope, p1.monitor, stream) { EmptyJob }
+    return SagaOutput(p1.scope, p1.monitor, stream)
   }
 }

--- a/android/android-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/core/WatchConnectivityEffect.kt
+++ b/android/android-rx-saga/src/main/java/org/swiften/redux/android/saga/rx/core/WatchConnectivityEffect.kt
@@ -16,7 +16,6 @@ import android.net.NetworkRequest
 import android.os.Build
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
@@ -67,6 +66,6 @@ internal class WatchConnectivityEffect(private val context: Context) : SagaEffec
       }
     }
 
-    return SagaOutput(p1.scope, p1.monitor, stream.toFlowable(BackpressureStrategy.BUFFER)) { EmptyJob }
+    return SagaOutput(p1.scope, p1.monitor, stream.toFlowable(BackpressureStrategy.BUFFER))
   }
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
@@ -95,3 +95,8 @@ interface IReduxStore<GState> :
   IReduxUnsubscriberProvider,
   IDeinitializerProvider
   where GState : Any
+
+/** [IActionDispatcher] that does not do any dispatching and simply returns [EmptyJob]. */
+object NoopActionDispatcher : IActionDispatcher {
+  override fun invoke(p1: IReduxAction): IAsyncJob<*> = EmptyJob
+}

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseMiddlewareTest.kt
@@ -9,10 +9,10 @@ package org.swiften.redux.core
 /** Mock test class to provide some utilities */
 open class BaseMiddlewareTest {
   fun <GState> mockMiddlewareInput(state: GState): MiddlewareInput<GState> {
-    return MiddlewareInput({ EmptyJob }, { state }, { _, _ -> ReduxSubscription.EMPTY })
+    return MiddlewareInput(NoopActionDispatcher, { state }, { _, _ -> ReduxSubscription.EMPTY })
   }
 
-  fun mockDispatchWrapper(dispatch: IActionDispatcher = { EmptyJob }): DispatchWrapper {
+  fun mockDispatchWrapper(dispatch: IActionDispatcher = NoopActionDispatcher): DispatchWrapper {
     return DispatchWrapper.root(dispatch)
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/CallEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/CallEffect.kt
@@ -6,7 +6,6 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Single
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.ISagaEffect
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
@@ -25,6 +24,6 @@ internal class CallEffect<P, R>(
   private val transformer: (P) -> Single<R>
 ) : SagaEffect<R>() where P : Any, R : Any {
   override fun invoke(p1: SagaInput) = this.source.invoke(p1).flatMap {
-    SagaOutput(p1.scope, p1.monitor, this.transformer(it).toFlowable()) { EmptyJob }
+    SagaOutput(p1.scope, p1.monitor, this.transformer(it).toFlowable())
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/FromEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/FromEffect.kt
@@ -6,7 +6,6 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Flowable
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
@@ -21,6 +20,6 @@ internal class FromEffect<R>(
   private val stream: Flowable<R>
 ) : SagaEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
-    return SagaOutput(p1.scope, p1.monitor, this.stream) { EmptyJob }
+    return SagaOutput(p1.scope, p1.monitor, this.stream)
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/JustEffect.kt
@@ -6,7 +6,6 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Flowable.just
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
@@ -20,6 +19,6 @@ import org.swiften.redux.saga.common.SingleSagaEffect
  */
 internal class JustEffect<R>(private val value: R) : SingleSagaEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
-    return SagaOutput(p1.scope, p1.monitor, just(this.value)) { EmptyJob }
+    return SagaOutput(p1.scope, p1.monitor, just(this.value))
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/NothingEffect.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/NothingEffect.kt
@@ -6,7 +6,6 @@
 package org.swiften.redux.saga.rx
 
 import io.reactivex.Flowable
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.saga.common.ISagaOutput
 import org.swiften.redux.saga.common.SagaEffect
 import org.swiften.redux.saga.common.SagaInput
@@ -19,6 +18,6 @@ import org.swiften.redux.saga.common.SagaInput
  */
 internal class NothingEffect<R> : SagaEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
-    return SagaOutput(p1.scope, p1.monitor, Flowable.empty()) { EmptyJob }
+    return SagaOutput(p1.scope, p1.monitor, Flowable.empty())
   }
 }

--- a/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
+++ b/common/common-rx-saga/src/main/kotlin/org/swiften/redux/saga/rx/SagaOutput.kt
@@ -11,9 +11,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.rx2.rxSingle
 import org.swiften.redux.core.DefaultUniqueIDProvider
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IUniqueIDProvider
+import org.swiften.redux.core.NoopActionDispatcher
 import org.swiften.redux.saga.common.ISagaMonitor
 import org.swiften.redux.saga.common.ISagaOutput
 import java.util.concurrent.TimeUnit
@@ -41,7 +41,7 @@ class SagaOutput<T : Any>(
   private val monitor: ISagaMonitor,
   stream: Flowable<T>,
   private val onDispose: () -> Unit = {},
-  override val onAction: IActionDispatcher
+  override val onAction: IActionDispatcher = NoopActionDispatcher
 ) : ISagaOutput<T>,
   IUniqueIDProvider by DefaultUniqueIDProvider(),
   CoroutineScope by scope {
@@ -58,7 +58,7 @@ class SagaOutput<T : Any>(
       monitor: ISagaMonitor,
       creator: suspend CoroutineScope.() -> T
     ): ISagaOutput<T> where T : Any {
-      return SagaOutput(scope, monitor, scope.rxSingle { creator() }.toFlowable()) { EmptyJob }
+      return SagaOutput(scope, monitor, scope.rxSingle { creator() }.toFlowable())
     }
 
     /**
@@ -74,7 +74,7 @@ class SagaOutput<T : Any>(
       monitor: ISagaMonitor,
       outputs: Collection<SagaOutput<T>>
     ): SagaOutput<T> where T : Any {
-      return SagaOutput(scope, monitor, Flowable.merge(outputs.map { it.stream })) { EmptyJob }
+      return SagaOutput(scope, monitor, Flowable.merge(outputs.map { it.stream }))
     }
   }
 
@@ -94,7 +94,7 @@ class SagaOutput<T : Any>(
   }
 
   private fun <T2> with(newStream: Flowable<T2>): ISagaOutput<T2> where T2 : Any {
-    return SagaOutput(this.scope, this.monitor, newStream, { this.dispose() }) { EmptyJob }
+    return SagaOutput(this.scope, this.monitor, newStream, { this.dispose() })
   }
 
   override fun <T2> map(transform: (T) -> T2): ISagaOutput<T2> where T2 : Any {

--- a/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
+++ b/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
@@ -30,6 +30,7 @@ import org.swiften.redux.core.IReducer
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxActionWithKey
 import org.swiften.redux.core.IReduxStore
+import org.swiften.redux.core.NoopActionDispatcher
 import org.swiften.redux.core.applyMiddlewares
 import org.swiften.redux.saga.common.CommonSagaEffectTest
 import org.swiften.redux.saga.common.ISagaEffect
@@ -389,7 +390,7 @@ class SagaEffectTest : CommonSagaEffectTest() {
       .invoke(SagaInput(monitor))
 
     val sourceOutput2 = just(2).selectFromState(State::class) { 4 }
-      .invoke(SagaInput(monitor, { State() }) { EmptyJob })
+      .invoke(SagaInput(monitor, { State() }, NoopActionDispatcher))
 
     // When && Then
     assertEquals(sourceOutput1.awaitFor(this.timeout), 3)

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/CommonSaga.kt
@@ -8,13 +8,13 @@ package org.swiften.redux.saga.common
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IAsyncJob
 import org.swiften.redux.core.IReduxAction
 import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.core.IStateGetter
 import org.swiften.redux.core.IUniqueIDProvider
+import org.swiften.redux.core.NoopActionDispatcher
 
 /** Created by haipham on 2019/01/07 */
 /**
@@ -54,7 +54,7 @@ class SagaInput(
   ) : this(GlobalScope, monitor, lastState, dispatch)
 
   constructor(monitor: ISagaMonitor, dispatch: IActionDispatcher) : this(monitor, {}, dispatch)
-  constructor(monitor: ISagaMonitor) : this(monitor, { EmptyJob })
+  constructor(monitor: ISagaMonitor) : this(monitor, NoopActionDispatcher)
 }
 
 /**

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
@@ -8,6 +8,8 @@ package org.swiften.redux.saga.common
 import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IDispatcherProvider
+import org.swiften.redux.core.NoopActionDispatcher
+import java.util.concurrent.ConcurrentHashMap
 
 /** Created by viethai.pham on 2019/02/22 */
 /**
@@ -24,14 +26,16 @@ interface ISagaMonitor : IDispatcherProvider {
 
 /** Default implementation of [ISagaMonitor]. */
 class SagaMonitor : ISagaMonitor {
-  private val dispatchers = HashMap<String, IActionDispatcher>()
+  private val dispatchers = ConcurrentHashMap<String, IActionDispatcher>()
 
   override val dispatch: IActionDispatcher = { a ->
     this@SagaMonitor.dispatchers.forEach { it.value(a) }; EmptyJob
   }
 
   override fun addOutputDispatcher(id: String, dispatch: IActionDispatcher) {
-    this.dispatchers[id] = dispatch
+    if (dispatch != NoopActionDispatcher) {
+      this.dispatchers[id] = dispatch
+    }
   }
 
   override fun removeOutputDispatcher(id: String) {

--- a/common/common-thunk/src/test/kotlin/org/swiften/redux/thunk/ThunkMiddlewareTest.kt
+++ b/common/common-thunk/src/test/kotlin/org/swiften/redux/thunk/ThunkMiddlewareTest.kt
@@ -20,6 +20,7 @@ import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.EnhancedReduxStore
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IReduxAction
+import org.swiften.redux.core.NoopActionDispatcher
 import org.swiften.redux.core.ThreadSafeStore
 import org.swiften.redux.core.combineMiddlewares
 import java.util.Collections.synchronizedList
@@ -49,11 +50,11 @@ class ThunkMiddlewareTest : BaseMiddlewareTest() {
     // Then
     runBlocking {
       assertTrue(thunkAction is IReduxThunkAction<*, *, *>)
-      assertTrue(successCast.payload(GlobalScope, { EmptyJob }, { 0 }, object :
+      assertTrue(successCast.payload(GlobalScope, NoopActionDispatcher, { 0 }, object :
         IDependency {}) is Unit)
 
       try {
-        failureCast.payload(GlobalScope, { EmptyJob }, {}, 0)
+        failureCast.payload(GlobalScope, NoopActionDispatcher, {}, 0)
         fail("Should not have completed")
       } catch (e: Throwable) { }
     }


### PR DESCRIPTION
This is especially useful for **SagaMonitor** because now it only has to store meaningful action dispatchers, i.e.:

```kotlin
if (dispatcher != NoopActionDispatcher) {...}
```

This will help reduce the number of active action dispatchers in **SagaMonitor** dramatically.