### PR TITLE
Reimplement default subscriber ID provider to use an incrementing Long

### DIFF
--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/SubscriberID.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/SubscriberID.kt
@@ -5,7 +5,8 @@
 
 package org.swiften.redux.core
 
-import java.util.UUID
+import org.swiften.redux.core.DefaultUniqueIDProvider.Companion.CURRENT_ID
+import java.util.concurrent.atomic.AtomicLong
 
 /** Created by viethai.pham on 2019/02/21 */
 /** Provide a unique subscriber ID for [IReduxStore.subscribe]. */
@@ -14,7 +15,11 @@ interface IUniqueIDProvider {
   val uniqueID: String
 }
 
-/** Default implementation of [IUniqueIDProvider] that simply uses [UUID.randomUUID]. */
+/** Default implementation of [IUniqueIDProvider] that simply uses incrementing [CURRENT_ID]. */
 class DefaultUniqueIDProvider : IUniqueIDProvider {
-  override val uniqueID: String = UUID.randomUUID().toString()
+  companion object {
+    private val CURRENT_ID = AtomicLong()
+  }
+
+  override val uniqueID: String = CURRENT_ID.incrementAndGet().toString()
 }

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/SubscriberIDTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/SubscriberIDTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) haipham 2019. All rights reserved.
+ * Any attempt to reproduce this source code in any form shall be met with legal actions.
+ */
+
+package org.swiften.redux.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Collections.synchronizedList
+
+/** Created by viethai.pham on 2019/03/01 */
+class SubscriberIDTest {
+  @Test
+  fun `Creating unique IDs with default ID provider should not create duplicate IDs`() {
+    // Setup
+    val iteration = 1000000
+    val idProviders = synchronizedList(arrayListOf<IUniqueIDProvider>())
+
+    // When
+    val jobs = (0 until iteration).map {
+      GlobalScope.launch(Dispatchers.IO) { idProviders.add(DefaultUniqueIDProvider()) }
+    }
+
+    runBlocking {
+      jobs.joinAll()
+
+      // Then
+      assertEquals(
+        idProviders.map { it.uniqueID }.sorted(),
+        (1 until iteration + 1).map { "$it" }.sorted()
+      )
+    }
+  }
+}


### PR DESCRIPTION
Update default subscriber ID to not use UUID anymore, since having numerous UUIDs could have some performance impact.