### PR TITLE
Reimplement subscriber ID to use Long instead of String

### DIFF
--- a/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
+++ b/android/android-lifecycle/src/test/java/org/swiften/redux/android/ui/lifecycle/BaseLifecycleTest.kt
@@ -60,7 +60,7 @@ open class BaseLifecycleTest {
   }
 
   class TestInjector(override val lastState: IStateGetter<Int> = { 0 }) : IFullPropInjector<Int> {
-    val subscriptions = ConcurrentHashMap<String, IReduxSubscription>()
+    val subscriptions = ConcurrentHashMap<Long, IReduxSubscription>()
     val injectionCount get() = this.subscriptions.size
 
     override val unsubscribe: IReduxUnsubscriber = { id ->

--- a/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
+++ b/android/android-recyclerview/src/main/java/org/swiften/redux/android/ui/recyclerview/RecyclerAdapter.kt
@@ -67,7 +67,7 @@ abstract class DelegateRecyclerAdapter<GState, LState, OutProp, VH, VHState, VHA
    * [ReduxListAdapter.composite], we need to keep track of these IDs because otherwise there is
    * no way to perform [IPropInjector.unsubscribe] for each [VH] instances.
    */
-  internal val viewHolderIDs = Collections.synchronizedSet(hashSetOf<String>())
+  internal val viewHolderIDs = Collections.synchronizedSet(hashSetOf<Long>())
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
     return this.adapter.onCreateViewHolder(parent, viewType)

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
@@ -28,10 +28,10 @@ typealias IStateGetter<GState> = () -> GState
  * identifies that subscriber. The resulting [IReduxSubscription] can be used to unsubscribe.
  * @param GState The global state type.
  */
-typealias IReduxSubscriber<GState> = (String, (GState) -> Unit) -> IReduxSubscription
+typealias IReduxSubscriber<GState> = (Long, (GState) -> Unit) -> IReduxSubscription
 
 /** Unsubscribe from state updates for a specified subscriber id. */
-typealias IReduxUnsubscriber = (String) -> Unit
+typealias IReduxUnsubscriber = (Long) -> Unit
 
 /** Represents a Redux action. */
 interface IReduxAction

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/LoggingMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/LoggingMiddleware.kt
@@ -5,7 +5,6 @@
 
 package org.swiften.redux.core
 
-import java.util.UUID
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -18,14 +17,13 @@ import kotlin.concurrent.withLock
  */
 internal class LoggingMiddleware<GState>(
   private val logger: (GState, IReduxAction?) -> Unit
-) : IMiddleware<GState> {
+) : IMiddleware<GState>, IUniqueIDProvider by DefaultUniqueIDProvider() {
   override fun invoke(p1: MiddlewareInput<GState>): DispatchMapper {
     return { wrapper ->
       val lock = ReentrantLock()
-      val subscriberId = "${this@LoggingMiddleware}${UUID.randomUUID()}"
       var lastAction: IReduxAction? = null
 
-      val subscription = p1.subscriber(subscriberId) {
+      val subscription = p1.subscriber(this@LoggingMiddleware.uniqueID) {
         lock.withLock { this@LoggingMiddleware.logger(it, lastAction) }
       }
 

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/NestedRouter.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/NestedRouter.kt
@@ -65,6 +65,7 @@ class NestedRouter private constructor (private val navigator: (IRouterScreen) -
       return
     }
 
+    println("Redux ${this.subRouters}")
     if (this.navigator(screen)) return
     for (subRouter in this.subRouters) { if (subRouter.navigate(screen)) return }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/SubscriberID.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/SubscriberID.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicLong
 /** Provide a unique subscriber ID for [IReduxStore.subscribe]. */
 interface IUniqueIDProvider {
   /** The unique ID to pass to [IReduxStore.subscribe] and [IReduxStore.unsubscribe]. */
-  val uniqueID: String
+  val uniqueID: Long
 }
 
 /** Default implementation of [IUniqueIDProvider] that simply uses incrementing [CURRENT_ID]. */
@@ -21,5 +21,5 @@ class DefaultUniqueIDProvider : IUniqueIDProvider {
     private val CURRENT_ID = AtomicLong()
   }
 
-  override val uniqueID: String = CURRENT_ID.incrementAndGet().toString()
+  override val uniqueID: Long = CURRENT_ID.incrementAndGet()
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
@@ -22,7 +22,7 @@ class ThreadSafeStore<GState>(
   override val reducer: IReducer<GState, IReduxAction>
 ) : IReduxStore<GState> where GState : Any {
   private val lock = ReentrantReadWriteLock()
-  private val subscribers = HashMap<String, (GState) -> Unit>()
+  private val subscribers = HashMap<Long, (GState) -> Unit>()
 
   override val lastState = { this.lock.read { this.state } }
 

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseStoreTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseStoreTest.kt
@@ -110,9 +110,9 @@ abstract class BaseStoreTest : CoroutineScope {
     // Setup
     val store = this.createStore()
     val receivedUpdates = AtomicInteger()
-    store.subscribe("1") { receivedUpdates.incrementAndGet() }
-    store.subscribe("2") { receivedUpdates.incrementAndGet() }
-    store.subscribe("3") { receivedUpdates.incrementAndGet() }
+    store.subscribe(1L) { receivedUpdates.incrementAndGet() }
+    store.subscribe(2L) { receivedUpdates.incrementAndGet() }
+    store.subscribe(3L) { receivedUpdates.incrementAndGet() }
 
     // / When
     runBlocking {

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/SubscriberIDTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/SubscriberIDTest.kt
@@ -31,10 +31,8 @@ class SubscriberIDTest {
       jobs.joinAll()
 
       // Then
-      assertEquals(
-        idProviders.map { it.uniqueID }.sorted(),
-        (1 until iteration + 1).map { "$it" }.sorted()
-      )
+      val generatedIDs = idProviders.map { it.uniqueID }.toSet()
+      assertEquals(generatedIDs.size, iteration)
     }
   }
 }

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/SubscriptionTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/SubscriptionTest.kt
@@ -20,7 +20,7 @@ class SubscriptionTest {
   fun `Unsubscribing from multiple threads should perform only once`() {
     // Setup
     val unsubCount = AtomicInteger()
-    val subscription = ReduxSubscription("") { unsubCount.incrementAndGet() }
+    val subscription = ReduxSubscription(-1L) { unsubCount.incrementAndGet() }
 
     // When
     (0 until 100).forEach { GlobalScope.launch { subscription.unsubscribe() } }
@@ -38,8 +38,8 @@ class SubscriptionTest {
   fun `Unsubscribing from composite subscription should perform only once`() {
     // Setup
     var unsubCount = 0
-    val subscriptions = (0 until 100).map { ReduxSubscription("$it") { unsubCount += 1 } }
-    val composite = CompositeReduxSubscription.create("")
+    val subscriptions = (0 until 100).map { ReduxSubscription(it.toLong()) { unsubCount += 1 } }
+    val composite = CompositeReduxSubscription.create(-1L)
 
     runBlocking {
       // When
@@ -57,8 +57,8 @@ class SubscriptionTest {
   fun `Removing subscription from composite should work`() {
     // Setup
     var unsubCount = 0
-    val subscription = ReduxSubscription("123") { unsubCount += 1 }
-    val composite = CompositeReduxSubscription.create("")
+    val subscription = ReduxSubscription(123L) { unsubCount += 1 }
+    val composite = CompositeReduxSubscription.create(-1L)
 
     // When
     composite.remove(subscription)

--- a/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
+++ b/common/common-rx-saga/src/test/kotlin/org/swiften/redux/saga/rx/SagaEffectTest.kt
@@ -169,7 +169,7 @@ abstract class OverridableSagaEffectTest : CommonSagaEffectTest() {
   ) {
     // Setup
     class Action(val value: Int) : IReduxAction
-    val dispatchers = ConcurrentHashMap<String, IActionDispatcher>()
+    val dispatchers = ConcurrentHashMap<Long, IActionDispatcher>()
     val setCount = AtomicInteger(0)
     val removeCount = AtomicInteger(0)
 
@@ -178,12 +178,12 @@ abstract class OverridableSagaEffectTest : CommonSagaEffectTest() {
         dispatchers.forEach { it.value(action) }; EmptyJob
       }
 
-      override fun addOutputDispatcher(id: String, dispatch: IActionDispatcher) {
+      override fun addOutputDispatcher(id: Long, dispatch: IActionDispatcher) {
         dispatchers[id] = dispatch
         setCount.incrementAndGet()
       }
 
-      override fun removeOutputDispatcher(id: String) {
+      override fun removeOutputDispatcher(id: Long) {
         /** If no id found, do not increment remove count. */
         dispatchers.remove(id)?.also { removeCount.incrementAndGet() }
       }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMonitor.kt
@@ -18,27 +18,27 @@ import java.util.concurrent.ConcurrentHashMap
  */
 interface ISagaMonitor : IDispatcherProvider {
   /** Store [dispatch] with a unique [id]. */
-  fun addOutputDispatcher(id: String, dispatch: IActionDispatcher)
+  fun addOutputDispatcher(id: Long, dispatch: IActionDispatcher)
 
   /** Remove the associated [IActionDispatcher] instance. */
-  fun removeOutputDispatcher(id: String)
+  fun removeOutputDispatcher(id: Long)
 }
 
 /** Default implementation of [ISagaMonitor]. */
 class SagaMonitor : ISagaMonitor {
-  private val dispatchers = ConcurrentHashMap<String, IActionDispatcher>()
+  private val dispatchers = ConcurrentHashMap<Long, IActionDispatcher>()
 
   override val dispatch: IActionDispatcher = { a ->
     this@SagaMonitor.dispatchers.forEach { it.value(a) }; EmptyJob
   }
 
-  override fun addOutputDispatcher(id: String, dispatch: IActionDispatcher) {
+  override fun addOutputDispatcher(id: Long, dispatch: IActionDispatcher) {
     if (dispatch != NoopActionDispatcher) {
       this.dispatchers[id] = dispatch
     }
   }
 
-  override fun removeOutputDispatcher(id: String) {
+  override fun removeOutputDispatcher(id: Long) {
     this.dispatchers.remove(id)
   }
 }

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
@@ -40,7 +40,7 @@ class SagaMiddlewareTest : BaseMiddlewareTest() {
     val monitor = SagaMonitor()
     val effects = outputs.map<ISagaOutput<Any>, ISagaEffect<Any>> { o -> { o } }
     val input = this.mockMiddlewareInput(0)
-    outputs.forEachIndexed { i, o -> monitor.addOutputDispatcher("$i", o.onAction) }
+    outputs.forEachIndexed { i, o -> monitor.addOutputDispatcher(i.toLong(), o.onAction) }
 
     val wrappedDispatch = SagaMiddleware.create(EmptyCoroutineContext, monitor, effects)
       .invoke(input)(this.mockDispatchWrapper())

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
@@ -78,7 +78,7 @@ open class PropInjector<GState : Any> protected constructor(
   IStateGetterProvider<GState> by store,
   IReduxUnsubscriberProvider,
   IDeinitializerProvider by store {
-  private val subscriptions = ConcurrentHashMap<String, IReduxSubscription>()
+  private val subscriptions = ConcurrentHashMap<Long, IReduxSubscription>()
 
   override val unsubscribe: IReduxUnsubscriber = { id ->
     this.subscriptions.remove(id)?.unsubscribe()


### PR DESCRIPTION
Long IDs instead of String so that we can utilize them for other purposes, such as comparing which object was created earlier (esp. if we use **DefaultUniqueIDProvider** delegate).