### PR TITLE
Sorted sub-router

### DIFF
--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/NestedRouter.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/NestedRouter.kt
@@ -18,8 +18,19 @@ import kotlin.concurrent.withLock
  * won't be a situation whereby the user has gone through thousands of [IVetoableRouter]-enabled
  * screens, thus significantly increasing the size of [subRouters].
  * @param navigator The navigation function that will be called before we touch [subRouters].
+ * @param comparator A [Comparator] that will be used to sort [subRouters]. This will be done to
+ * determine which [IVetoableRouter] should be invoked first, and should be used in conjunction
+ * with [DefaultUniqueIDProvider] thanks to its auto-incrementing of provided IDs (so that we know
+ * the order of object creation).
  */
-class NestedRouter private constructor (private val navigator: (IRouterScreen) -> Boolean) : IRouter<IRouterScreen> {
+class NestedRouter private constructor (
+  private val navigator: (IRouterScreen) -> Boolean,
+  private val comparator: Comparator<IVetoableRouter> = object : Comparator<IVetoableRouter> {
+    override fun compare(p0: IVetoableRouter?, p1: IVetoableRouter?): Int {
+      return if (p0 != null && p1 != null) (p1.uniqueID - p0.uniqueID).toInt() else 0
+    }
+  }
+) : IRouter<IRouterScreen> {
   companion object {
     /**
      * Create an [IRouter] instance that provides locking mechanisms for an internal [NestedRouter].
@@ -43,29 +54,39 @@ class NestedRouter private constructor (private val navigator: (IRouterScreen) -
   }
 
   sealed class Screen : IRouterScreen {
-    data class RegisterSubRouter(val subRouter: IVetoableRouter<IRouterScreen>) : Screen()
-    data class UnregisterSubRouter(val subRouter: IVetoableRouter<IRouterScreen>) : Screen()
+    data class RegisterSubRouter(val subRouter: IVetoableRouter) : Screen()
+    data class UnregisterSubRouter(val subRouter: IVetoableRouter) : Screen()
   }
 
-  private val subRouters = arrayListOf<IVetoableRouter<IRouterScreen>>()
+  private val subRouters = arrayListOf<IVetoableRouter>()
 
   override fun navigate(screen: IRouterScreen) {
     if (when (screen) {
         is Screen.RegisterSubRouter -> {
           if (!this.subRouters.contains(screen.subRouter)) {
             this.subRouters.add(0, screen.subRouter)
+            this.subRouters.sortWith(this@NestedRouter.comparator)
           }
 
           true
         }
 
-        is Screen.UnregisterSubRouter -> { this.subRouters.remove(screen.subRouter); true }
+        is Screen.UnregisterSubRouter -> {
+          for (i in 0 until this.subRouters.size) {
+            if (this.subRouters.elementAtOrNull(i)?.uniqueID == screen.subRouter.uniqueID) {
+              this.subRouters.removeAt(i)
+              break
+            }
+          }
+
+          true
+        }
+
         else -> false
     }) {
       return
     }
 
-    println("Redux ${this.subRouters}")
     if (this.navigator(screen)) return
     for (subRouter in this.subRouters) { if (subRouter.navigate(screen)) return }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Router.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Router.kt
@@ -29,13 +29,12 @@ interface IRouter<in Screen> : IDeinitializerProvider where Screen : IRouterScre
  * navigation happened. This can be used in a main-sub router set-up whereby there is a [Collection]
  * of [IVetoableRouter], and every time a [Screen] arrives, the first [IVetoableRouter] that returns
  * true for [navigate] performs the navigation.
- * @param Screen The app [IRouterScreen] type.
  */
-interface IVetoableRouter<in Screen> where Screen : IRouterScreen {
+interface IVetoableRouter : IUniqueIDProvider {
   /**
    * Navigate to an [IRouterScreen]. How this is done is left to the app's specific implementation.
-   * @param screen The incoming [Screen] instance.
+   * @param screen The incoming [IRouterScreen] instance.
    * @return A [Boolean] value.
    */
-  fun navigate(screen: Screen): Boolean
+  fun navigate(screen: IRouterScreen): Boolean
 }

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainActivity.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainActivity.kt
@@ -27,7 +27,7 @@ class MainActivity : AppCompatActivity(),
   IUniqueIDProvider by DefaultUniqueIDProvider(),
   IPropContainer<Unit, MainActivity.Action>,
   IPropLifecycleOwner<Redux.State, Unit> by NoopPropLifecycleOwner(),
-  IVetoableRouter<IRouterScreen> {
+  IVetoableRouter {
   companion object : IPropMapper<Redux.State, Unit, Unit, Action> {
     override fun mapState(state: Redux.State, outProp: Unit) = Unit
 
@@ -42,8 +42,8 @@ class MainActivity : AppCompatActivity(),
   }
 
   class Action(
-    val registerSubRouter: (IVetoableRouter<IRouterScreen>) -> Unit,
-    val unregisterSubRouter: (IVetoableRouter<IRouterScreen>) -> Unit,
+    val registerSubRouter: (IVetoableRouter) -> Unit,
+    val unregisterSubRouter: (IVetoableRouter) -> Unit,
     val goToMainFragment: () -> Unit,
     val goBack: () -> Unit
   )

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
@@ -32,7 +32,7 @@ class MainFragment : Fragment(),
   IUniqueIDProvider by DefaultUniqueIDProvider(),
   IPropContainer<MainFragment.S, MainFragment.A>,
   IPropLifecycleOwner<MainFragment.ILocalState, Unit> by NoopPropLifecycleOwner(),
-  IVetoableRouter<IRouterScreen> {
+  IVetoableRouter {
   companion object : IPropMapper<ILocalState, Unit, S, A> {
     override fun mapAction(dispatch: IActionDispatcher, outProp: Unit): A {
       return A(
@@ -51,8 +51,8 @@ class MainFragment : Fragment(),
 
   data class S(val selectedPage: Int = 0) : Serializable
   class A(
-    val registerSubRouter: (IVetoableRouter<IRouterScreen>) -> Unit,
-    val unregisterSubRouter: (IVetoableRouter<IRouterScreen>) -> Unit,
+    val registerSubRouter: (IVetoableRouter) -> Unit,
+    val unregisterSubRouter: (IVetoableRouter) -> Unit,
     val selectPage: (Int) -> Unit
   )
 


### PR DESCRIPTION
Several changes:
- **IVetoableRouter** no longer has generic **Screen** requirement, so that it's shorter to write.
- **IVetoableRouter** now extends from **IUniqueIDProvider**.
- **NestedRouter** now sorts its sub-router based on a comparator to determine which sub-router should be invoked first.