### PR TITLE
Add BatchAction and BatchDispatchMiddleware to handle batches of actions

### DIFF
--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/BatchDispatchMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/BatchDispatchMiddleware.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) haipham 2019. All rights reserved.
+ * Any attempt to reproduce this source code in any form shall be met with legal actions.
+ */
+
+package org.swiften.redux.core
+
+/** Created by viethai.pham on 2019/03/03 */
+/**
+ * An [IReduxAction] that contains multiple other [IReduxAction] instances that can be dispatched
+ * individually.
+ */
+class BatchAction(internal val actions: Collection<IReduxAction>) : IReduxAction {
+  constructor(vararg actions: IReduxAction) : this(actions.toList())
+}
+
+/**
+ * [IMiddleware] that detects if an action if a [BatchAction]. If it is, access [BatchAction.actions]
+ * and dispatch them individually.
+ */
+class BatchDispatchMiddleware internal constructor() : IMiddleware<Any> {
+  companion object {
+    fun create(): IMiddleware<Any> = BatchDispatchMiddleware()
+  }
+
+  override fun invoke(p1: MiddlewareInput<Any>): DispatchMapper {
+    return { wrapper ->
+      DispatchWrapper.wrap(wrapper, "batch") { action ->
+        wrapper.dispatch(action)
+
+        when (action) {
+          is BatchAction -> action.actions.map { p1.dispatch(it) }
+        }
+
+        EmptyJob
+      }
+    }
+  }
+}

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/BaseMiddlewareTest.kt
@@ -8,8 +8,10 @@ package org.swiften.redux.core
 /** Created by haipham on 2018/01/27 */
 /** Mock test class to provide some utilities */
 open class BaseMiddlewareTest {
-  fun <GState> mockMiddlewareInput(state: GState): MiddlewareInput<GState> {
-    return MiddlewareInput(NoopActionDispatcher, { state }, { _, _ -> ReduxSubscription.EMPTY })
+  fun <GState> mockMiddlewareInput(state: GState,
+    dispatch: IActionDispatcher = NoopActionDispatcher
+  ): MiddlewareInput<GState> {
+    return MiddlewareInput(dispatch, { state }, { _, _ -> ReduxSubscription.EMPTY })
   }
 
   fun mockDispatchWrapper(dispatch: IActionDispatcher = NoopActionDispatcher): DispatchWrapper {

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/BatchDispatchMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/BatchDispatchMiddlewareTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) haipham 2019. All rights reserved.
+ * Any attempt to reproduce this source code in any form shall be met with legal actions.
+ */
+
+package org.swiften.redux.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Created by viethai.pham on 2019/03/03 */
+class BatchDispatchMiddlewareTest : BaseMiddlewareTest() {
+  @Test
+  fun  `Dispatching batch action should dispatch all child actions`() {
+    // Setup
+    data class Action(val value: Int) : IReduxAction
+    val iteration = 10000
+    val dispatched = arrayListOf<IReduxAction>()
+    val input = this.mockMiddlewareInput({}) { dispatched.add(it); EmptyJob }
+    val wrappedDispatch = BatchDispatchMiddleware.create()(input)(this.mockDispatchWrapper())
+
+    // When
+    val batchedActions = (0 until iteration).map { Action(it) }
+    wrappedDispatch.dispatch(BatchAction(*batchedActions.toTypedArray()))
+
+    // Then
+    assertEquals(dispatched, batchedActions)
+  }
+}


### PR DESCRIPTION
Add **BatchDispatchMiddleware**, which can be used like so:

```kotlin
val store = applyMiddlewares<State>(
  ...,
  BatchDispatchMiddleware.create(),
  ...
)(FinalStore(..., ...))
```

Then group actions with **BatchAction**:

```kotlin
dispatch(BatchAction(Action1, Action2, ...))
```