### PR TITLE
Proper middleware await

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -68,6 +68,8 @@ project(':common:common-core') {
   dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutines"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutines"
+    testImplementation project(":common:common-thunk")
+    testImplementation project(":common:common-saga")
   }
 }
 

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncJob.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/AsyncJob.kt
@@ -42,9 +42,9 @@ interface IAsyncJob<T> where T : Any {
 }
 
 /** Represents an empty [IAsyncJob] that does not do anything. */
-object EmptyJob : IAsyncJob<Unit> {
+object EmptyJob : IAsyncJob<Any> {
   override fun await() = Unit
-  override fun await(defaultValue: Unit) = this.await()
+  override fun await(defaultValue: Any) = this.await()
   override fun awaitFor(timeoutMillis: Long) = this.await()
 }
 

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/BatchDispatchMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/BatchDispatchMiddleware.kt
@@ -23,16 +23,17 @@ class BatchDispatchMiddleware internal constructor() : IMiddleware<Any> {
     fun create(): IMiddleware<Any> = BatchDispatchMiddleware()
   }
 
+  @Suppress("UNCHECKED_CAST")
   override fun invoke(p1: MiddlewareInput<Any>): DispatchMapper {
     return { wrapper ->
       DispatchWrapper.wrap(wrapper, "batch") { action ->
-        wrapper.dispatch(action)
+        val dispatchJobs = arrayListOf(wrapper.dispatch(action))
 
         when (action) {
-          is BatchAction -> action.actions.map { p1.dispatch(it) }
+          is BatchAction -> dispatchJobs.addAll(action.actions.map { p1.dispatch(it) })
         }
 
-        EmptyJob
+        BatchJob(dispatchJobs) as IAsyncJob<Any>
       }
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/BatchDispatchMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/BatchDispatchMiddleware.kt
@@ -28,11 +28,13 @@ class BatchDispatchMiddleware internal constructor() : IMiddleware<Any> {
   override fun invoke(p1: MiddlewareInput<Any>): DispatchMapper {
     return { wrapper ->
       DispatchWrapper.wrap(wrapper, "batch") { action ->
+        val dispatchJob = wrapper.dispatch(action)
+
         when (action) {
           is BatchAction -> action.actions.map { p1.dispatch(it) }
         }
 
-        wrapper.dispatch(action)
+        dispatchJob
       }
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/BatchDispatchMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/BatchDispatchMiddleware.kt
@@ -10,8 +10,9 @@ package org.swiften.redux.core
  * An [IReduxAction] that contains multiple other [IReduxAction] instances that can be dispatched
  * individually.
  */
-class BatchAction(internal val actions: Collection<IReduxAction>) : IReduxAction {
+data class BatchAction(internal val actions: Collection<IReduxAction>) : IReduxAction {
   constructor(vararg actions: IReduxAction) : this(actions.toList())
+  override fun toString(): String = "Batch action, containing ${this.actions.size} child actions"
 }
 
 /**
@@ -27,13 +28,11 @@ class BatchDispatchMiddleware internal constructor() : IMiddleware<Any> {
   override fun invoke(p1: MiddlewareInput<Any>): DispatchMapper {
     return { wrapper ->
       DispatchWrapper.wrap(wrapper, "batch") { action ->
-        val dispatchJobs = arrayListOf(wrapper.dispatch(action))
-
         when (action) {
-          is BatchAction -> dispatchJobs.addAll(action.actions.map { p1.dispatch(it) })
+          is BatchAction -> action.actions.map { p1.dispatch(it) }
         }
 
-        BatchJob(dispatchJobs) as IAsyncJob<Any>
+        wrapper.dispatch(action)
       }
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
@@ -7,7 +7,7 @@ package org.swiften.redux.core
 
 /** Created by haipham on 2018/03/31 */
 /** Represents an [IReduxAction] dispatcher. */
-typealias IActionDispatcher = (IReduxAction) -> IAsyncJob<*>
+typealias IActionDispatcher = (IReduxAction) -> IAsyncJob<Any>
 
 /**
  * Represents a Redux reducer that reduce a [IReduxAction] onto a previous state to produce a new
@@ -98,5 +98,5 @@ interface IReduxStore<GState> :
 
 /** [IActionDispatcher] that does not do any dispatching and simply returns [EmptyJob]. */
 object NoopActionDispatcher : IActionDispatcher {
-  override fun invoke(p1: IReduxAction): IAsyncJob<*> = EmptyJob
+  override fun invoke(p1: IReduxAction): IAsyncJob<Any> = EmptyJob
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchWrapper.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchWrapper.kt
@@ -31,7 +31,7 @@ class DispatchWrapper private constructor (val id: String, val dispatch: IAction
      * @param dispatch The [DispatchWrapper.dispatch] of the resulting [DispatchWrapper].
      * @return A [DispatchWrapper] instance.
      */
-    fun wrap(wrapper: DispatchWrapper, id: String, dispatch: IActionDispatcher): DispatchWrapper {
+    fun wrap(wrapper: DispatchWrapper, id: String, dispatch: (IReduxAction) -> IAsyncJob<Any>): DispatchWrapper {
       return DispatchWrapper("$id -> ${wrapper.id}", dispatch)
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/LoggingMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/LoggingMiddleware.kt
@@ -15,9 +15,21 @@ import kotlin.concurrent.withLock
  * @param GState The global state type.
  * @param logger Function to specify how [GState] and [IReduxAction] are formatted.
  */
-internal class LoggingMiddleware<GState>(
+class LoggingMiddleware<GState> internal constructor(
   private val logger: (GState, IReduxAction?) -> Unit
 ) : IMiddleware<GState>, IUniqueIDProvider by DefaultUniqueIDProvider() {
+  companion object {
+    /**
+     * Create a [LoggingMiddleware] with [logger].
+     * @param GState The global state type.
+     * @param logger See [LoggingMiddleware.logger].
+     * @return A [LoggingMiddleware] instance.
+     */
+    fun <GState> create(
+      logger: (GState, IReduxAction?) -> Unit = { s, a -> println("Redux: action $a, state $s") }
+    ): IMiddleware<GState> = LoggingMiddleware(logger)
+  }
+
   override fun invoke(p1: MiddlewareInput<GState>): DispatchMapper {
     return { wrapper ->
       val lock = ReentrantLock()
@@ -38,13 +50,3 @@ internal class LoggingMiddleware<GState>(
     }
   }
 }
-
-/**
- * Create a [LoggingMiddleware] with [logger].
- * @param GState The global state type.
- * @param logger See [LoggingMiddleware.logger].
- * @return A [LoggingMiddleware] instance.
- */
-fun <GState> createLoggingMiddleware(
-  logger: (GState, IReduxAction?) -> Unit = { s, a -> println("Redux: action $a, state $s") }
-): IMiddleware<GState> = LoggingMiddleware(logger)

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Preset.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Preset.kt
@@ -11,10 +11,10 @@ sealed class DefaultReduxAction : IReduxAction {
   object Dummy : DefaultReduxAction()
   object Deinitialize : DefaultReduxAction()
 
-  /** Replace the current [State] with [state] */
+  /** Replace the current [State] with [state]. */
   data class ReplaceState<out State>(val state: State) : DefaultReduxAction()
 
-  /** Replace the current [GState] with [fn] */
+  /** Replace the current [GState] with [fn]. */
   class MapState<GState>(val fn: (GState) -> GState) : DefaultReduxAction()
 }
 

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/RouterMiddleware.kt
@@ -37,7 +37,7 @@ class RouterMiddleware<out Screen> private constructor (
   override fun invoke(p1: MiddlewareInput<Any>): DispatchMapper {
     return { wrapper ->
       DispatchWrapper.wrap(wrapper, "router") { action ->
-        wrapper.dispatch(action)
+        val dispatchJob = wrapper.dispatch(action)
 
         /**
          * If [action] is an [Screen] instance, use the [router] to navigate to the associated
@@ -53,7 +53,7 @@ class RouterMiddleware<out Screen> private constructor (
           this@RouterMiddleware.router.deinitialize()
         }
 
-        EmptyJob
+        dispatchJob
       }
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeDispatcher.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeDispatcher.kt
@@ -19,7 +19,7 @@ class ThreadSafeDispatcher(
   private val lock: ReentrantLock = ReentrantLock(),
   private val dispatch: IActionDispatcher
 ) : IActionDispatcher {
-  override fun invoke(p1: IReduxAction): IAsyncJob<*> {
+  override fun invoke(p1: IReduxAction): IAsyncJob<Any> {
     return this.lock.withLock { this@ThreadSafeDispatcher.dispatch(p1) }
   }
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeDispatcher.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeDispatcher.kt
@@ -18,7 +18,7 @@ import kotlin.concurrent.withLock
 class ThreadSafeDispatcher(
   private val lock: ReentrantLock = ReentrantLock(),
   private val dispatch: IActionDispatcher
-) : IActionDispatcher {
+) : IActionDispatcher by dispatch {
   override fun invoke(p1: IReduxAction): IAsyncJob<Any> {
     return this.lock.withLock { this@ThreadSafeDispatcher.dispatch(p1) }
   }

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncJobTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncJobTest.kt
@@ -58,10 +58,11 @@ class AsyncJobTest {
   fun `Batch job await with timeout should throw error on time out`() {
     // Setup
     val iteration = 10000
+    val context = Dispatchers.IO
 
     val childJobs = (0 until iteration)
-      .map { i -> GlobalScope.async(Dispatchers.IO, start = CoroutineStart.LAZY) { delay(800); i } }
-      .map { CoroutineJob(it) }
+      .map { i -> GlobalScope.async(context, start = CoroutineStart.LAZY) { delay(800); i } }
+      .map { CoroutineJob(context, it) }
 
     val batchJob = BatchJob(*childJobs.toTypedArray())
 
@@ -73,10 +74,11 @@ class AsyncJobTest {
   fun `Batch job await should wait for all jobs to finish and results should be sequential`() {
     // Setup
     val iteration = 100
+    val context = Dispatchers.IO
 
     val childJobs = (0 until iteration)
-      .map { i -> GlobalScope.async(Dispatchers.IO, start = CoroutineStart.LAZY) { i } }
-      .map { CoroutineJob(it) }
+      .map { i -> GlobalScope.async(context, start = CoroutineStart.LAZY) { i } }
+      .map { CoroutineJob(context, it) }
 
     val batchJob = BatchJob(*childJobs.toTypedArray())
 

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/LoggingMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/LoggingMiddlewareTest.kt
@@ -13,18 +13,23 @@ class LoggingMiddlewareTest : BaseMiddlewareTest() {
   @Test
   fun `Dispatching actions should call logger`() {
     // Setup
+    data class Action(val value: Int) : IReduxAction
     var logged = 0
     val store = ThreadSafeStore(0) { a, _ -> a }
-    val middleware = LoggingMiddleware.create<Int> { _, _ -> logged += 1 }
+
+    val middleware = LoggingMiddleware.create<Int> { _, a ->
+      logged += 1; println("Logged: ${logged}, current action $a")
+    }
+
     val wrappedDispatch = applyMiddlewares(middleware)(store).dispatch
 
     // When
-    wrappedDispatch(DefaultReduxAction.Dummy)
-    wrappedDispatch(DefaultReduxAction.Dummy)
+    wrappedDispatch(Action(0))
+    wrappedDispatch(Action(1))
     wrappedDispatch(DefaultReduxAction.Deinitialize)
-    wrappedDispatch(DefaultReduxAction.Dummy)
-    wrappedDispatch(DefaultReduxAction.Dummy)
-    wrappedDispatch(DefaultReduxAction.Dummy)
+    wrappedDispatch(Action(2))
+    wrappedDispatch(Action(3))
+    wrappedDispatch(Action(4))
 
     // Then
     // Value is 3 due to last value being relayed on subscription.

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/LoggingMiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/LoggingMiddlewareTest.kt
@@ -15,7 +15,7 @@ class LoggingMiddlewareTest : BaseMiddlewareTest() {
     // Setup
     var logged = 0
     val store = ThreadSafeStore(0) { a, _ -> a }
-    val middleware = createLoggingMiddleware<Int> { _, _ -> logged += 1 }
+    val middleware = LoggingMiddleware.create<Int> { _, _ -> logged += 1 }
     val wrappedDispatch = applyMiddlewares(middleware)(store).dispatch
 
     // When

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/MiddlewareTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/MiddlewareTest.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.swiften.redux.saga.common.SagaMiddleware
 import org.swiften.redux.thunk.ThunkMiddleware
@@ -119,7 +118,8 @@ class MiddlewareTest : BaseMiddlewareTest() {
         override fun deinitialize() {}
       }),
       SagaMiddleware.create(arrayListOf()),
-      LoggingMiddleware.create()
+      LoggingMiddleware.create(),
+      AsyncMiddleware.create()
     )(baseStore)
 
     val wrappedDispatch = store.dispatch
@@ -128,6 +128,6 @@ class MiddlewareTest : BaseMiddlewareTest() {
     val nextState = wrappedDispatch(BatchAction((0 until iteration).map { Action(it) })).await()
 
     // Then
-    assertTrue(nextState is Int)
+    Assert.assertTrue(nextState is Int)
   }
 }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMiddleware.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMiddleware.kt
@@ -75,7 +75,7 @@ class SagaMiddleware private constructor (
        * value selection.
        */
       DispatchWrapper.wrap(wrapper, "saga", ThreadSafeDispatcher(lock) { action ->
-        val dispatchResults = wrapper.dispatch(action).await()
+        val dispatchResult = wrapper.dispatch(action).await()
         monitor.dispatch(action).await()
 
         /** If [action] is [DefaultReduxAction.Deinitialize], dispose of all [ISagaOutput]. */
@@ -84,7 +84,7 @@ class SagaMiddleware private constructor (
           scope.coroutineContext.cancel()
         }
 
-        JustJob(dispatchResults)
+        JustJob(dispatchResult)
       })
     }
   }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMiddleware.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/common/SagaMiddleware.kt
@@ -11,10 +11,10 @@ import kotlinx.coroutines.cancel
 import org.swiften.redux.core.DefaultReduxAction
 import org.swiften.redux.core.DispatchMapper
 import org.swiften.redux.core.DispatchWrapper
-import org.swiften.redux.core.EmptyJob
 import org.swiften.redux.core.IAsyncJob
 import org.swiften.redux.core.IMiddleware
 import org.swiften.redux.core.IReduxAction
+import org.swiften.redux.core.JustJob
 import org.swiften.redux.core.MiddlewareInput
 import org.swiften.redux.core.ThreadSafeDispatcher
 import java.util.concurrent.locks.ReentrantLock
@@ -75,7 +75,7 @@ class SagaMiddleware private constructor (
        * value selection.
        */
       DispatchWrapper.wrap(wrapper, "saga", ThreadSafeDispatcher(lock) { action ->
-        wrapper.dispatch(action).await()
+        val dispatchResults = wrapper.dispatch(action).await()
         monitor.dispatch(action).await()
 
         /** If [action] is [DefaultReduxAction.Deinitialize], dispose of all [ISagaOutput]. */
@@ -84,7 +84,7 @@ class SagaMiddleware private constructor (
           scope.coroutineContext.cancel()
         }
 
-        EmptyJob
+        JustJob(dispatchResults)
       })
     }
   }

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/common/SagaMiddlewareTest.kt
@@ -27,7 +27,7 @@ class SagaMiddlewareTest : BaseMiddlewareTest() {
     val dispatched = AtomicInteger()
 
     val dispatchers: List<IActionDispatcher> = (0 until 100).map {
-      fun(_: IReduxAction): IAsyncJob<*> {
+      fun(_: IReduxAction): IAsyncJob<Any> {
         dispatched.incrementAndGet()
         return EmptyJob
       }

--- a/common/common-thunk/src/main/kotlin/org/swiften/redux/thunk/ThunkMiddleware.kt
+++ b/common/common-thunk/src/main/kotlin/org/swiften/redux/thunk/ThunkMiddleware.kt
@@ -55,10 +55,34 @@ interface IReduxThunkAction<GState, GExt, Param> : IReduxAction {
  * @param external The external [GExt] argument.
  * @param context The [CoroutineContext] with which to perform async work.
  */
-internal class ThunkMiddleware<GExt>(
+class ThunkMiddleware<GExt>(
   private val external: GExt,
   private val context: CoroutineContext
-) : IMiddleware<Any> {
+) : IMiddleware<Any> where GExt : Any {
+  companion object {
+    /**
+     * Create a [ThunkMiddleware] with [context].
+     * @param GExt The external argument type.
+     * @param external The external [GExt] argument.
+     * @param context See [ThunkMiddleware.context].
+     * @return A [ThunkMiddleware] instance.
+     */
+    internal fun <GExt> create(external: GExt, context: CoroutineContext): IMiddleware<Any> where GExt : Any {
+      return ThunkMiddleware(external, context)
+    }
+
+    /**
+     * Create a [ThunkMiddleware] with a default [CoroutineContext]. This is made public so that users
+     * of this [ThunkMiddleware] cannot share its [CoroutineContext] with other users.
+     * @param GExt The external argument type.
+     * @param external The external [GExt] argument.
+     * @return A [ThunkMiddleware] instance.
+     */
+    fun <GExt> create(external: GExt): IMiddleware<Any> where GExt : Any {
+      return this.create(external, SupervisorJob())
+    }
+  }
+
   @Suppress("UNCHECKED_CAST")
   override fun invoke(p1: MiddlewareInput<Any>): DispatchMapper {
     val context = this@ThunkMiddleware.context
@@ -81,29 +105,4 @@ internal class ThunkMiddleware<GExt>(
       }
     }
   }
-}
-
-/**
- * Create a [ThunkMiddleware] with [context].
- * @param GExt The external argument type.
- * @param external The external [GExt] argument.
- * @param context See [ThunkMiddleware.context].
- * @return A [ThunkMiddleware] instance.
- */
-internal fun <GExt> createThunkMiddleware(
-  external: GExt,
-  context: CoroutineContext = SupervisorJob()
-): IMiddleware<Any> {
-  return ThunkMiddleware(external, context)
-}
-
-/**
- * Create a [ThunkMiddleware] with a default [CoroutineContext]. This is made public so that users
- * of this [ThunkMiddleware] cannot share its [CoroutineContext] with other users.
- * @param GExt The external argument type.
- * @param external The external [GExt] argument.
- * @return A [ThunkMiddleware] instance.
- */
-fun <GExt> createThunkMiddleware(external: GExt): IMiddleware<Any> {
-  return createThunkMiddleware(external, SupervisorJob())
 }

--- a/common/common-thunk/src/test/kotlin/org/swiften/redux/thunk/ThunkMiddlewareTest.kt
+++ b/common/common-thunk/src/test/kotlin/org/swiften/redux/thunk/ThunkMiddlewareTest.kt
@@ -84,7 +84,7 @@ class ThunkMiddlewareTest : BaseMiddlewareTest() {
     val dispatch: IActionDispatcher = { dispatched.add(it); EmptyJob }
     val baseStore = ThreadSafeStore(0) { s, _ -> s }
     val enhancedStore = EnhancedReduxStore(baseStore, dispatch)
-    val wrappedDispatch = combineMiddlewares<Int>(createThunkMiddleware(Unit))(enhancedStore)
+    val wrappedDispatch = combineMiddlewares<Int>(ThunkMiddleware.create(Unit))(enhancedStore)
 
     // When
     wrappedDispatch(ThunkAction(1))
@@ -103,7 +103,7 @@ class ThunkMiddlewareTest : BaseMiddlewareTest() {
     // Setup
     val dispatched = AtomicInteger(0)
     val job = Job()
-    val middleware = createThunkMiddleware(Unit, job)
+    val middleware = ThunkMiddleware.create(Unit, job)
     val dispatch: IActionDispatcher = { dispatched.incrementAndGet(); EmptyJob }
     val dispatchWrapper = this.mockDispatchWrapper(dispatch)
     val input = mockMiddlewareInput(0)

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenApplication.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/GardenApplication.kt
@@ -22,7 +22,7 @@ import org.swiften.redux.core.FinalStore
 import org.swiften.redux.core.RouterMiddleware
 import org.swiften.redux.core.applyMiddlewares
 import org.swiften.redux.saga.common.SagaMiddleware
-import org.swiften.redux.thunk.createThunkMiddleware
+import org.swiften.redux.thunk.ThunkMiddleware
 import org.swiften.redux.ui.IPropInjector
 
 /** Created by haipham on 2019/01/17 */
@@ -46,7 +46,7 @@ class GardenApplication : Application() {
           Redux.Saga.PlantSaga.allSagas(InjectorUtils.getPlantRepository(this))
         ).flatten()
       ),
-      createThunkMiddleware(dependency)
+      ThunkMiddleware.create(dependency)
     )(FinalStore(Redux.State(), Redux.Reducer))
 
     val injector = AndroidPropInjector(store)


### PR DESCRIPTION
Ensure proper jobs are returned for each middleware dispatch wrapper, so calling **job.await** actually waits for the result from upstream.

```kotlin
val store = applyMiddlewares<Int>(
  AsyncMiddleware.create(),
  ThunkMiddleware.create(Unit),
  BatchDispatchMiddleware.create(),
  RouterMiddleware.create(object : IRouter<IRouterScreen> {
    override fun navigate(screen: IRouterScreen) {}
    override fun deinitialize() {}
  }),
  SagaMiddleware.create(arrayListOf()),
  LoggingMiddleware.create()
)(baseStore)

val wrappedDispatch = store.dispatch
wrappedDispatch(BatchAction((0 until iteration).map { Action(it) })).await()
```

The result of **await** may not reflect the actual current state of the store if there is an **AsyncMiddleware** involved.