### PR TITLE
Allow subrouter to specify priority order

### DIFF
--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Router.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Router.kt
@@ -25,12 +25,21 @@ interface IRouter<in Screen> : IDeinitializerProvider where Screen : IRouterScre
 }
 
 /**
+ * Represents a provider for [subRouterPriority] - which is used to sort [NestedRouter.subRouters]
+ * based on priority. This allows us to determine which [IVetoableSubRouter] to be called first.
+ */
+interface ISubRouterPriorityProvider {
+  /** The priority of a [IVetoableSubRouter]. */
+  val subRouterPriority: Long
+}
+
+/**
  * Represents a router whose [navigate] returns a [Boolean] indicating whether a successful
  * navigation happened. This can be used in a main-sub router set-up whereby there is a [Collection]
- * of [IVetoableRouter], and every time a [IRouterScreen] arrives, the first [IVetoableRouter] that
- * returns true for [navigate] performs the navigation.
+ * of [IVetoableSubRouter], and every time a [IRouterScreen] arrives, the first [IVetoableSubRouter]
+ * that returns true for [navigate] performs the navigation.
  */
-interface IVetoableRouter : IUniqueIDProvider {
+interface IVetoableSubRouter : IUniqueIDProvider, ISubRouterPriorityProvider {
   /**
    * Navigate to an [IRouterScreen]. How this is done is left to the app's specific implementation.
    * @param screen The incoming [IRouterScreen] instance.

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainActivity.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainActivity.kt
@@ -12,7 +12,7 @@ import org.swiften.redux.core.DefaultUniqueIDProvider
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IRouterScreen
 import org.swiften.redux.core.IUniqueIDProvider
-import org.swiften.redux.core.IVetoableRouter
+import org.swiften.redux.core.IVetoableSubRouter
 import org.swiften.redux.core.NestedRouter
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
@@ -26,7 +26,7 @@ class MainActivity : AppCompatActivity(),
   IUniqueIDProvider by DefaultUniqueIDProvider(),
   IPropContainer<Unit, MainActivity.Action>,
   IPropLifecycleOwner<Redux.State, Unit> by NoopPropLifecycleOwner(),
-  IVetoableRouter {
+  IVetoableSubRouter {
   companion object : IPropMapper<Redux.State, Unit, Unit, Action> {
     override fun mapState(state: Redux.State, outProp: Unit) = Unit
 
@@ -40,8 +40,8 @@ class MainActivity : AppCompatActivity(),
   }
 
   class Action(
-    val registerSubRouter: (IVetoableRouter) -> Unit,
-    val unregisterSubRouter: (IVetoableRouter) -> Unit,
+    val registerSubRouter: (IVetoableSubRouter) -> Unit,
+    val unregisterSubRouter: (IVetoableSubRouter) -> Unit,
     val goBack: () -> Unit
   )
 
@@ -72,6 +72,8 @@ class MainActivity : AppCompatActivity(),
   override fun onBackPressed() {
     this.reduxProp.action.goBack()
   }
+
+  override val subRouterPriority: Long get() = this.uniqueID
 
   override fun navigate(screen: IRouterScreen): Boolean {
     return when (screen) {

--- a/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
+++ b/sample-android/sample-simple/src/main/java/org/swiften/redux/android/sample/MainFragment.kt
@@ -17,7 +17,7 @@ import org.swiften.redux.core.DefaultUniqueIDProvider
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IRouterScreen
 import org.swiften.redux.core.IUniqueIDProvider
-import org.swiften.redux.core.IVetoableRouter
+import org.swiften.redux.core.IVetoableSubRouter
 import org.swiften.redux.core.NestedRouter
 import org.swiften.redux.ui.IPropContainer
 import org.swiften.redux.ui.IPropLifecycleOwner
@@ -32,7 +32,7 @@ class MainFragment : Fragment(),
   IUniqueIDProvider by DefaultUniqueIDProvider(),
   IPropContainer<MainFragment.S, MainFragment.A>,
   IPropLifecycleOwner<MainFragment.ILocalState, Unit> by NoopPropLifecycleOwner(),
-  IVetoableRouter {
+  IVetoableSubRouter {
   companion object : IPropMapper<ILocalState, Unit, S, A> {
     override fun mapAction(dispatch: IActionDispatcher, outProp: Unit): A {
       return A(
@@ -51,8 +51,8 @@ class MainFragment : Fragment(),
 
   data class S(val selectedPage: Int = 0) : Serializable
   class A(
-    val registerSubRouter: (IVetoableRouter) -> Unit,
-    val unregisterSubRouter: (IVetoableRouter) -> Unit,
+    val registerSubRouter: (IVetoableSubRouter) -> Unit,
+    val unregisterSubRouter: (IVetoableSubRouter) -> Unit,
     val selectPage: (Int) -> Unit
   )
 
@@ -95,6 +95,8 @@ class MainFragment : Fragment(),
   override fun afterPropInjectionEnds(sp: StaticProp<ILocalState, Unit>) {
     this.reduxProp.action.unregisterSubRouter(this)
   }
+
+  override val subRouterPriority: Long get() = this.uniqueID
 
   override fun navigate(screen: IRouterScreen): Boolean {
     return when (screen) {


### PR DESCRIPTION
**IVetoableRouter** used to rely on **uniqueID** to sort **NestedRouter.subRouters**, objects that conform to this interface now needs to provide **subRouterPriority** to declare their priority in ordering.