### PR TITLE
feat(common-saga): refactor kotlin coroutines out of common-saga

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
 [*.{kt,kts,.gradle}]
 indent_size=2
 insert_final_newline=true
-max_line_length=off
+max_line_length=100

--- a/android/android-livedata-saga/src/test/java/org/swiften/redux/android/livedata/saga/LiveDataEffectTest.kt
+++ b/android/android-livedata-saga/src/test/java/org/swiften/redux/android/livedata/saga/LiveDataEffectTest.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -20,6 +21,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.swiften.redux.android.livedata.saga.LiveDataEffects.takeLiveData
 import org.swiften.redux.saga.CommonEffects.await
+import org.swiften.redux.saga.CommonEffects.from
 import org.swiften.redux.saga.SagaInput
 import org.swiften.redux.saga.flatMap
 import java.util.Collections
@@ -40,7 +42,7 @@ class LiveDataEffectTest {
     val finalValues = Collections.synchronizedList(arrayListOf<Int>())
 
     takeLiveData { data }
-      .flatMap { v -> await { delay(500); v } }
+      .flatMap { v -> from(rxSingle { delay(500); v }) }
       .invoke(SagaInput())
       .subscribe({ finalValues.add(it) })
 

--- a/android/android-ui/src/main/java/org/swiften/redux/android/ui/AndroidPropInjector.kt
+++ b/android/android-ui/src/main/java/org/swiften/redux/android/ui/AndroidPropInjector.kt
@@ -27,18 +27,16 @@ import org.swiften.redux.ui.StaticProp
 class AndroidPropInjector<GState>(
   store: IReduxStore<GState>,
   private val runner: AndroidUtil.IMainThreadRunner = AndroidUtil.MainThreadRunner
-) : PropInjector<GState>(store) where GState : Any {
+) : PropInjector<GState>(store) {
   override fun <LState, OutProp, View, State, Action> inject(
     outProp: OutProp,
     view: View,
     mapper: IPropMapper<LState, OutProp, State, Action>
   ): IReduxSubscription where
-    LState : Any,
     View : IUniqueIDProvider,
     View : IPropContainer<State, Action>,
-    View : IPropLifecycleOwner<LState, OutProp>,
-    State : Any,
-    Action : Any {
+    View : IPropLifecycleOwner<LState, OutProp>
+  {
     return super.inject(outProp, object :
       IUniqueIDProvider by view,
       IPropContainer<State, Action>,

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -147,8 +147,8 @@ project(":android:android-recyclerview") {
   dependencies {
     api project(":android:android-ui")
     api project(":android:android-lifecycle")
-    implementation "androidx.lifecycle:lifecycle-runtime:$project.ext.lifecycle"
-    implementation "androidx.recyclerview:recyclerview:$project.ext.recyclerView"
+    implementation "androidx.lifecycle:lifecycle-runtime:${project.ext.lifecycle}"
+    implementation "androidx.recyclerview:recyclerview:${project.ext.recyclerView}"
     testImplementation project(path: ":android:android-lifecycle", configuration: 'testArtifacts')
   }
 }
@@ -156,20 +156,19 @@ project(":android:android-recyclerview") {
 project(":android:android-saga") {
   dependencies {
     api project(":common:common-saga")
-    implementation "io.reactivex.rxjava2:rxjava:$project.ext.rxJava"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$project.ext.kotlinCoroutines"
-    implementation "io.reactivex.rxjava2:rxkotlin:$project.ext.rxKotlin"
+    implementation "io.reactivex.rxjava2:rxjava:${project.ext.rxJava}"
+    implementation "io.reactivex.rxjava2:rxkotlin:${project.ext.rxKotlin}"
   }
 }
 
 project(":android:android-livedata-saga") {
   dependencies {
     api project(":common:common-saga")
-    implementation "androidx.lifecycle:lifecycle-livedata:$project.ext.lifecycle"
-    implementation "io.reactivex.rxjava2:rxjava:$project.ext.rxJava"
-    implementation "io.reactivex.rxjava2:rxandroid:$project.ext.rxAndroid"
-    testImplementation "androidx.arch.core:core-testing:$project.ext.androidxArchCoreTest"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$project.ext.kotlinCoroutines"
+    implementation "androidx.lifecycle:lifecycle-livedata:${project.ext.lifecycle}"
+    implementation "io.reactivex.rxjava2:rxjava:${project.ext.rxJava}"
+    implementation "io.reactivex.rxjava2:rxandroid:${project.ext.rxAndroid}"
+    testImplementation "androidx.arch.core:core-testing:${project.ext.androidxArchCoreTest}"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${project.ext.kotlinCoroutines}"
   }
 }
 
@@ -177,7 +176,7 @@ project(":android:android-router") {
   dependencies {
     api project(":common:common-core")
     api project(":android:android-util")
-    implementation "androidx.appcompat:appcompat:$project.ext.appCompat"
+    implementation "androidx.appcompat:appcompat:${project.ext.appCompat}"
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -165,11 +165,11 @@ project(":android:android-saga") {
 project(":android:android-livedata-saga") {
   dependencies {
     api project(":common:common-saga")
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$project.ext.kotlinCoroutines"
     implementation "androidx.lifecycle:lifecycle-livedata:$project.ext.lifecycle"
     implementation "io.reactivex.rxjava2:rxjava:$project.ext.rxJava"
     implementation "io.reactivex.rxjava2:rxandroid:$project.ext.rxAndroid"
     testImplementation "androidx.arch.core:core-testing:$project.ext.androidxArchCoreTest"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$project.ext.kotlinCoroutines"
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,14 @@ subprojects {
     // Make sure the latest JitPack releases are used.
     resolutionStrategy.cacheChangingModulesFor(24, "hours")
   }
+
+  tasks {
+    withType(Test::class) {
+      testLogging {
+        showStandardStreams = true
+      }
+    }
+  }
 }
 
 val clean by tasks.registering(type = Delete::class) {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -93,7 +93,6 @@ project(":common:common-core") {
   dependencies {
     val implementation by configurations
     val testImplementation by configurations
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutines"]}")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutines"]}")
     testImplementation(project(path = ":common:common-thunk"))
     testImplementation(project(path = ":common:common-saga"))

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -91,7 +91,6 @@ Package test jar so that other projects can depend on test code from this projec
 
 project(":common:common-core") {
   dependencies {
-    val implementation by configurations
     val testImplementation by configurations
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutines"]}")
     testImplementation(project(path = ":common:common-thunk"))
@@ -106,8 +105,9 @@ project(":common:common-thunk") {
     val testImplementation by configurations
     val testArtifacts by configurations
     implementation(project(path = ":common:common-core"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutines"]}")
+    testImplementation(project(path = ":common:common-core"))
     testImplementation(project(path = ":common:common-core", configuration = testArtifacts.name))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutines"]}")
   }
 }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -119,11 +119,12 @@ project(":common:common-saga") {
     val testImplementation by configurations
     val testArtifacts by configurations
     api(project(path = ":common:common-core"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutines"]}")
     implementation("io.reactivex.rxjava2:rxjava:${project.extra["rxJava"]}")
     implementation("io.reactivex.rxjava2:rxkotlin:${project.extra["rxKotlin"]}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${project.extra["kotlinCoroutines"]}")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:${project.extra["mockito"]}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutines"]}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${project.extra["kotlinCoroutines"]}")
+    testImplementation(project(path = ":common:common-core"))
     testImplementation(project(path = ":common:common-core", configuration = testArtifacts.name))
   }
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Awaitable.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Awaitable.kt
@@ -5,14 +5,9 @@
 
 package org.swiften.redux.core
 
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.yield
-import kotlin.coroutines.CoroutineContext
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 /** Created by haipham on 2019/02/16 */
 /**
@@ -61,63 +56,89 @@ data class JustAwaitable<T>(private val value: T) : IAwaitable<T> where T : Any 
 }
 
 /**
- * Represents an [IAwaitable] that handles [Job]. It waits for [job] to resolve synchronously with
- * [runBlocking]. If [awaitFor] is used, make sure [job] is cooperative with cancellation.
- * @param T The return type of [await].
- * @param context The [CoroutineContext] to perform waiting on.
- * @param job The [Job] to be resolved.
+ * Represents an [IAwaitable] that waits for all [IAwaitable] in [awaitables] to finish, then return
+ * a [Collection] of [awaitables] return values.
+ * @param awaitables A [Collection] of [IAwaitable].
  */
-data class CoroutineAwaitable<T>(
-  private val context: CoroutineContext,
-  private val job: Deferred<T>
-) : IAwaitable<T> where T : Any {
-  override fun await(): T {
-    return runBlocking(this.context) { this@CoroutineAwaitable.job.await() }
+class BatchAwaitable<T>(
+  private val awaitables: Collection<IAwaitable<T>>,
+  private val executor: IExecutor
+) : IAwaitable<Collection<T>> where T : Any {
+  /** Execute a function on another thread. The exact implementation is left to the caller */
+  fun interface IExecutor {
+    fun invoke(runnable: Runnable)
   }
 
-  override fun await(defaultValue: T) = try { this.await() } catch (e: Throwable) { defaultValue }
+  class DeadlockException(message: String? = null) : Exception(message) {}
 
-  @Throws(TimeoutCancellationException::class)
-  override fun awaitFor(timeoutMillis: Long): T {
-    return runBlocking(this.context) { withTimeout(timeoutMillis) { this@CoroutineAwaitable.await() } }
-  }
-}
+  constructor(
+    executor: IExecutor,
+    vararg awaitables: IAwaitable<T>,
+  ) : this(awaitables = awaitables.toList(), executor = executor)
 
-/**
- * Represents an [IAwaitable] that waits for all [IAwaitable] in [jobs] to finish, then return a
- * [Collection] of [jobs] return values.
- * @param jobs A [Collection] of [IAwaitable].
- */
-data class BatchAwaitable<T>(private val jobs: Collection<IAwaitable<T>>) : IAwaitable<Collection<T>> where T : Any {
-  constructor(vararg jobs: IAwaitable<T>) : this(jobs.toList())
-
-  override fun await(): Collection<T> = this.jobs.map { it.await() }
+  override fun await(): Collection<T> = this.awaitables.map { it.await() }
 
   override fun await(defaultValue: Collection<T>): Collection<T> {
     return try { this.await() } catch (e: Throwable) { defaultValue }
   }
 
-  @Throws(TimeoutCancellationException::class)
+  @Throws(
+    DeadlockException::class,
+    InterruptedException::class,
+    TimeoutException::class
+  )
   override fun awaitFor(timeoutMillis: Long): Collection<T> {
-    return runBlocking {
-      withTimeout(timeoutMillis) {
-        val results = arrayListOf<T>()
+    val semaphore = Semaphore(1)
+    var awaitableResults: Collection<T> = arrayListOf()
+    var awaitableException: Exception? = null
+    semaphore.tryAcquire()
 
-        for (job in this@BatchAwaitable.jobs) {
-          if (this.isActive) {
-            val jobResult = job.await()
+    val originalThread = Thread.currentThread()
 
-            if (this.isActive) {
-              results.add(jobResult)
-              continue
-            }
-          }
-
-          yield()
+    this.executor.invoke {
+      if (originalThread == Thread.currentThread()) {
+        awaitableException = DeadlockException("Must invoke await on a different thread")
+      } else {
+        try {
+          awaitableResults = this@BatchAwaitable.await()
+        } catch (exception: Exception) {
+          awaitableException = exception
         }
-
-        results
       }
+
+      semaphore.release()
     }
+
+    val didNotTimeout = semaphore.tryAcquire(timeoutMillis, TimeUnit.MILLISECONDS)
+
+    if (awaitableException != null) {
+      throw awaitableException as Exception
+    }
+
+    if (!didNotTimeout) {
+      throw TimeoutException()
+    }
+
+    return awaitableResults
+
+//    return runBlocking {
+//      withTimeout(timeoutMillis) {
+//        val results = arrayListOf<T>()
+//
+//        for (job in this@BatchAwaitable.awaitables) {
+//          if (this.isActive) {
+//            val jobResult = job.await()
+//
+//            if (this.isActive) {
+//              results.add(jobResult)
+//              continue
+//            }
+//          }
+//
+//          yield()
+//        }
+//
+//        results
+//      }
   }
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Core.kt
@@ -7,7 +7,7 @@ package org.swiften.redux.core
 
 /** Created by haipham on 2018/03/31 */
 /** Represents an [IReduxAction] dispatcher. */
-typealias IActionDispatcher = (IReduxAction) -> IAwaitable<Any>
+typealias IActionDispatcher = (IReduxAction) -> IAwaitable<*>
 
 /**
  * Represents a Redux reducer that reduce a [IReduxAction] onto a previous state to produce a new
@@ -46,7 +46,7 @@ interface IReduxActionWithKey : IReduxAction {
  * @param GState The global state type.
  * @param Action The [IReduxAction] type.
  */
-interface IReducerProvider<GState, Action> where GState : Any, Action : IReduxAction {
+interface IReducerProvider<GState, Action> where Action : IReduxAction {
   val reducer: IReducer<GState, Action>
 }
 
@@ -59,7 +59,7 @@ interface IDispatcherProvider {
  * Represents an object that provides [IStateGetter].
  * @param GState The global state type.
  */
-interface IStateGetterProvider<out GState> where GState : Any {
+interface IStateGetterProvider<out GState> {
   val lastState: IStateGetter<GState>
 }
 
@@ -73,7 +73,7 @@ interface IDeinitializerProvider {
  * Represents an object that provides [IReduxSubscriber].
  * @param GState The global state type.
  */
-interface IReduxSubscriberProvider<out GState> where GState : Any {
+interface IReduxSubscriberProvider<out GState> {
   val subscribe: IReduxSubscriber<GState>
 }
 
@@ -94,9 +94,8 @@ interface IReduxStore<GState> :
   IReduxSubscriberProvider<GState>,
   IReduxUnsubscriberProvider,
   IDeinitializerProvider
-  where GState : Any
 
 /** [IActionDispatcher] that does not do any dispatching and simply returns [EmptyAwaitable]. */
 object NoopActionDispatcher : IActionDispatcher {
-  override fun invoke(p1: IReduxAction): IAwaitable<Any> = EmptyAwaitable
+  override fun invoke(p1: IReduxAction): IAwaitable<*> = EmptyAwaitable
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/DefaultActionStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/DefaultActionStore.kt
@@ -12,7 +12,7 @@ package org.swiften.redux.core
  * @param state See [ThreadSafeStore.state].
  * @param reducer See [ThreadSafeStore.reducer].
  */
-class DefaultActionStore<GState>(state: GState, reducer: IReducer<GState, IReduxAction>) : IReduxStore<GState> where GState : Any {
+class DefaultActionStore<GState>(state: GState, reducer: IReducer<GState, IReduxAction>) : IReduxStore<GState> {
   private val store: IReduxStore<GState>
   init { this.store = ThreadSafeStore(state, ReduxReducerWrapper(reducer)) }
 

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchWrapper.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/DispatchWrapper.kt
@@ -31,7 +31,7 @@ class DispatchWrapper private constructor (val id: String, val dispatch: IAction
      * @param dispatch The [DispatchWrapper.dispatch] of the resulting [DispatchWrapper].
      * @return A [DispatchWrapper] instance.
      */
-    fun wrap(wrapper: DispatchWrapper, id: String, dispatch: (IReduxAction) -> IAwaitable<Any>): DispatchWrapper {
+    fun wrap(wrapper: DispatchWrapper, id: String, dispatch: (IReduxAction) -> IAwaitable<*>): DispatchWrapper {
       return DispatchWrapper("$id -> ${wrapper.id}", dispatch)
     }
   }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/FinalStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/FinalStore.kt
@@ -12,7 +12,7 @@ package org.swiften.redux.core
  * @param GState The global state type.
  * @param store An [IReduxStore] instance.
  */
-class FinalStore<GState : Any> private constructor(store: IReduxStore<GState>) :
+class FinalStore<GState> private constructor(store: IReduxStore<GState>) :
   IReduxStore<GState> by store {
   constructor(state: GState, reducer: IReducer<GState, IReduxAction>) :
     this(fun (): IReduxStore<GState> {

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/Middleware.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/Middleware.kt
@@ -41,7 +41,7 @@ class MiddlewareInput<out GState>(
  * @param store An [IReduxStore] instance.
  * @param dispatch An overriding [IActionDispatcher] instance.
  */
-class EnhancedReduxStore<GState : Any>(
+class EnhancedReduxStore<GState>(
   private val store: IReduxStore<GState>,
   override val dispatch: IActionDispatcher
 ) : IReduxStore<GState> by store
@@ -55,7 +55,7 @@ class EnhancedReduxStore<GState : Any>(
  */
 fun <GState> combineMiddlewares(
   middlewares: Collection<IMiddleware<GState>>
-): (IReduxStore<GState>) -> IActionDispatcher where GState : Any {
+): (IReduxStore<GState>) -> IActionDispatcher {
   /**
    * Use a lazy [IActionDispatcher] to ensure that a [MiddlewareInput] has access to the master
    * [IActionDispatcher]. This is done so that invoking [IActionDispatcher] within an [IMiddleware]
@@ -90,7 +90,7 @@ fun <GState> combineMiddlewares(
  */
 fun <GState> combineMiddlewares(
   vararg middlewares: IMiddleware<GState>
-): (IReduxStore<GState>) -> IActionDispatcher where GState : Any {
+): (IReduxStore<GState>) -> IActionDispatcher {
   return combineMiddlewares(middlewares.asList())
 }
 
@@ -102,7 +102,7 @@ fun <GState> combineMiddlewares(
  */
 fun <GState> applyMiddlewares(
   middlewares: Collection<IMiddleware<GState>>
-): (IReduxStore<GState>) -> IReduxStore<GState> where GState : Any =
+): (IReduxStore<GState>) -> IReduxStore<GState> =
   fun(store): IReduxStore<GState> {
     val wrappedDispatch = combineMiddlewares(middlewares)(store)
     return EnhancedReduxStore(store, wrappedDispatch)
@@ -116,6 +116,6 @@ fun <GState> applyMiddlewares(
  */
 fun <GState> applyMiddlewares(
   vararg middlewares: IMiddleware<GState>
-): (IReduxStore<GState>) -> IReduxStore<GState> where GState : Any {
+): (IReduxStore<GState>) -> IReduxStore<GState> {
   return applyMiddlewares(middlewares.asList())
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeDispatcher.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeDispatcher.kt
@@ -19,7 +19,7 @@ class ThreadSafeDispatcher(
   private val lock: ReentrantLock = ReentrantLock(),
   private val dispatch: IActionDispatcher
 ) : IActionDispatcher by dispatch {
-  override fun invoke(p1: IReduxAction): IAwaitable<Any> {
+  override fun invoke(p1: IReduxAction): IAwaitable<*> {
     return this.lock.withLock { this@ThreadSafeDispatcher.dispatch(p1) }
   }
 }

--- a/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
+++ b/common/common-core/src/main/kotlin/org/swiften/redux/core/ThreadSafeStore.kt
@@ -20,7 +20,7 @@ import kotlin.concurrent.write
 class ThreadSafeStore<GState>(
   private var state: GState,
   override val reducer: IReducer<GState, IReduxAction>
-) : IReduxStore<GState> where GState : Any {
+) : IReduxStore<GState> {
   private val lock = ReentrantReadWriteLock()
   private val subscribers = HashMap<Long, (GState) -> Unit>()
 

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncJobTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncJobTest.kt
@@ -35,7 +35,7 @@ class AsyncJobTest {
   data class CoroutineAwaitable<T>(
     private val context: CoroutineContext,
     private val job: Deferred<T>
-  ) : IAwaitable<T> where T : Any {
+  ) : IAwaitable<T> {
     override fun await(): T {
       return runBlocking(this.context) { this@CoroutineAwaitable.job.await() }
     }

--- a/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncJobTest.kt
+++ b/common/common-core/src/test/kotlin/org/swiften/redux/core/AsyncJobTest.kt
@@ -6,47 +6,137 @@
 package org.swiften.redux.core
 
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeoutException
+import kotlin.coroutines.CoroutineContext
 
 /** Created by haipham on 2019/02/17 */
+@OptIn(DelicateCoroutinesApi::class)
 class AsyncJobTest {
+  /**
+   * Represents an [IAwaitable] that handles [Deferred]. It waits for [job] to resolve synchronously
+   * with [runBlocking]. If [awaitFor] is used, make sure [job] is cooperative with cancellation.
+   * @param T The return type of [await].
+   * @param context The [CoroutineContext] to perform waiting on.
+   * @param job The [Deferred] to be resolved.
+   */
+  data class CoroutineAwaitable<T>(
+    private val context: CoroutineContext,
+    private val job: Deferred<T>
+  ) : IAwaitable<T> where T : Any {
+    override fun await(): T {
+      return runBlocking(this.context) { this@CoroutineAwaitable.job.await() }
+    }
+
+    override fun await(defaultValue: T) = try { this.await() } catch (e: Throwable) { defaultValue }
+
+    @Throws(TimeoutCancellationException::class)
+    override fun awaitFor(timeoutMillis: Long): T {
+      return runBlocking(this.context) {
+        withTimeout(timeoutMillis) { this@CoroutineAwaitable.await() }
+      }
+    }
+  }
+
   @Test
-  fun `Batch job await with timeout should throw error on time out`() {
+  fun `Batch awaitable should fail if awaiting with time out on the same thread`() {
+    // Setup
+    val awaitable = JustAwaitable(value = 0)
+
+    // When
+    val batchAwaitable = BatchAwaitable(executor = { runnable ->
+      runnable.run()
+    }, awaitable)
+
+    // Then
+    assertThrows(BatchAwaitable.DeadlockException::class.java) {
+      batchAwaitable.awaitFor(0L)
+    }
+  }
+
+  @Test
+  fun `Batch awaitable should handle child await errors if awaiting with time out`() {
+    // Setup
+    val exception = ClassNotFoundException()
+    val executors = Executors.newFixedThreadPool(1)
+
+    val awaitable = object : IAwaitable<String> {
+      override fun await(): String {
+        throw exception
+      }
+
+      override fun await(defaultValue: String): String {
+        throw exception
+      }
+
+      override fun awaitFor(timeoutMillis: Long): String {
+        throw exception
+      }
+    }
+
+    // When
+    val batchAwaitable = BatchAwaitable(executor = { runnable ->
+      executors.submit(runnable)
+    }, awaitable)
+
+    // Then
+    assertThrows(ClassNotFoundException::class.java) {
+      batchAwaitable.awaitFor(1000L)
+    }
+  }
+
+  @Test
+  fun `Batch awaitable with timeout should throw error on time out`() {
     // Setup
     val iteration = 10000
     val context = Dispatchers.IO
 
-    val childJobs = (0 until iteration)
-      .map { i -> GlobalScope.async(context, start = CoroutineStart.LAZY) { delay(800); i } }
-      .map { CoroutineAwaitable(context, it) }
+    val awaitables = (0 until iteration)
+      .map { i ->
+        GlobalScope.async(context, start = CoroutineStart.LAZY) { delay(800); i }
+      }
+      .map { CoroutineAwaitable(context = context, job = it) }
 
-    val batchJob = BatchAwaitable(*childJobs.toTypedArray())
+    val executors = Executors.newFixedThreadPool(1)
+
+    val batchAwaitable = BatchAwaitable(executor = { runnable ->
+      executors.submit(runnable)
+    }, *awaitables.toTypedArray())
 
     // When && Then
-    assertThrows(TimeoutCancellationException::class.java) { batchJob.awaitFor(2000L) }
+    assertThrows(TimeoutException::class.java) { batchAwaitable.awaitFor(2000L) }
   }
 
   @Test
-  fun `Batch job await should wait for all jobs to finish and results should be sequential`() {
+  fun `Batch awaitable should wait for all awaitables to finish and results should be sequential`() {
     // Setup
     val iteration = 100
     val context = Dispatchers.IO
 
-    val childJobs = (0 until iteration)
+    val awaitables = (0 until iteration)
       .map { i -> GlobalScope.async(context, start = CoroutineStart.LAZY) { i } }
-      .map { CoroutineAwaitable(context, it) }
+      .map { CoroutineAwaitable(context = context, job = it) }
 
-    val batchJob = BatchAwaitable(*childJobs.toTypedArray())
+    val executors = Executors.newFixedThreadPool(1)
+
+    val batchAwaitable = BatchAwaitable(executor = { runnable ->
+      executors.submit(runnable)
+    }, *awaitables.toTypedArray())
 
     // When
-    val results = batchJob.await()
+    val results = batchAwaitable.await()
 
     // Then
     assertEquals(results.sorted(), (0 until iteration).toList())

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/AwaitEffect.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/AwaitEffect.kt
@@ -7,7 +7,7 @@ package org.swiften.redux.saga
 
 /** Created by viethai.pham on 2019/02/17 */
 /** Produces a value using [SagaInput] and [ISagaOutput.awaitFor]. */
-typealias IAwaitCreator<R> = suspend (SagaInput) -> R
+typealias IAwaitCreator<R> = (SagaInput) -> R
 
 /**
  * [SagaEffect] whose [ISagaOutput] is created from [creator], which is a function that creates
@@ -16,8 +16,8 @@ typealias IAwaitCreator<R> = suspend (SagaInput) -> R
  * @param R The result emission type.
  * @param creator An [IAwaitCreator] instance.
  */
-class AwaitEffect<R>(private val creator: IAwaitCreator<R>) : SingleSagaEffect<R>() where R : Any {
+class AwaitEffect<R>(private val creator: IAwaitCreator<R>) : SingleEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
-    return SagaOutput.from(p1, p1.monitor) { this@AwaitEffect.creator(p1) }
+    return SagaOutput.from(p1.monitor) { this@AwaitEffect.creator(p1) }
   }
 }

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/CommonEffects.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/CommonEffects.kt
@@ -6,6 +6,8 @@
 package org.swiften.redux.saga
 
 import io.reactivex.Flowable
+import io.reactivex.Maybe
+import io.reactivex.Single
 import org.swiften.redux.core.IReduxAction
 import kotlin.reflect.KClass
 
@@ -16,7 +18,7 @@ object CommonEffects {
    * Create an [AwaitEffect] instance.
    * @param R The result emission type.
    * @param creator See [AwaitEffect.creator].
-   * @return A [SingleSagaEffect] instance.
+   * @return A [SingleEffect] instance.
    */
   @JvmStatic
   fun <R> await(creator: IAwaitCreator<R>): AwaitEffect<R> where R : Any {
@@ -72,6 +74,22 @@ object CommonEffects {
    */
   @JvmStatic
   fun <R> from(stream: Flowable<R>): SagaEffect<R> where R : Any = FromEffect(stream)
+
+  /**
+   * Create a [FromEffect].
+   * @param R The result emission type.
+   * @param stream See [FromEffect.stream].
+   * @return A [SagaEffect] instance.
+   */
+  fun <R> from(stream: Single<R>): SagaEffect<R> where R : Any = this.from(stream.toFlowable())
+
+  /**
+   * Create a [FromEffect].
+   * @param R The result emission type.
+   * @param stream See [FromEffect.stream].
+   * @return A [SagaEffect] instance.
+   */
+  fun <R> from(stream: Maybe<R>): SagaEffect<R> where R : Any = this.from(stream.toFlowable())
 
   /**
    * Create an [AllEffect] instance.

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/CommonSaga.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/CommonSaga.kt
@@ -8,8 +8,6 @@ package org.swiften.redux.saga
 import io.reactivex.Scheduler
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IAwaitable
 import org.swiften.redux.core.IReduxAction
@@ -17,8 +15,6 @@ import org.swiften.redux.core.IReduxStore
 import org.swiften.redux.core.IStateGetter
 import org.swiften.redux.core.IUniqueIDProvider
 import org.swiften.redux.core.NoopActionDispatcher
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 
 /** Created by haipham on 2019/01/07 */
 /**
@@ -38,19 +34,15 @@ typealias ISagaEffectTransformer<R, R2> = (SagaEffect<R>) -> SagaEffect<R2>
 
 /**
  * [SagaInput] for an [ISagaEffect], which exposes a [IReduxStore]'s internal functionalities.
- * @param context A [CoroutineScope] instance.
  * @param lastState See [IReduxStore.lastState].
  * @param dispatch See [IReduxStore.dispatch].
  */
 class SagaInput(
-  private val context: CoroutineContext = EmptyCoroutineContext,
   internal val dispatch: IActionDispatcher = NoopActionDispatcher,
   internal val lastState: IStateGetter<*> = {},
   val monitor: ISagaMonitor = SagaMonitor(),
   internal val scheduler: Scheduler = Schedulers.io()
-) : CoroutineScope {
-  override val coroutineContext: CoroutineContext get() = this.context + SupervisorJob()
-}
+)
 
 /**
  * Stream values for a [ISagaEffect]. This stream has functional operators that can transform
@@ -73,7 +65,7 @@ interface ISagaOutput<T> : IAwaitable<T>, IUniqueIDProvider where T : Any {
   /**
    * Flatten emissions from [ISagaOutput] produced by [transform].
    * @param T2 The type of emission of the resulting [ISagaOutput].
-   * @param transform Function that flat maps from [T] to [ISagaOutput] in a [CoroutineScope].
+   * @param transform Function that flat maps from [T] to [ISagaOutput].
    * @return An [ISagaOutput] instance.
    */
   fun <T2> flatMap(transform: (T) -> ISagaOutput<T2>): ISagaOutput<T2> where T2 : Any
@@ -82,7 +74,7 @@ interface ISagaOutput<T> : IAwaitable<T>, IUniqueIDProvider where T : Any {
    * Flatten emissions from [ISagaOutput] produced by [transform], but accept only those from
    * the latest one.
    * @param T2 The type of emission of the resulting [ISagaOutput].
-   * @param transform Function that switch maps from [T] to [ISagaOutput] in a [CoroutineScope].
+   * @param transform Function that switch maps from [T] to [ISagaOutput].
    * @return An [ISagaOutput] instance.
    */
   fun <T2> switchMap(transform: (T) -> ISagaOutput<T2>): ISagaOutput<T2> where T2 : Any
@@ -117,9 +109,9 @@ abstract class SagaEffect<R> : ISagaEffect<R> where R : Any {
  * a stream.
  * @param R The result emission type.
  */
-abstract class SingleSagaEffect<R> : SagaEffect<R>() where R : Any {
+abstract class SingleEffect<R> : SagaEffect<R>() where R : Any {
   /**
-   * See [ISagaOutput.await]. We invoke this [SingleSagaEffect] with [input] then call
+   * See [ISagaOutput.await]. We invoke this [SingleEffect] with [input] then call
    * [ISagaOutput.await].
    * @param input A [SagaInput] instance.
    * @param defaultValue A [R] instance.
@@ -130,7 +122,7 @@ abstract class SingleSagaEffect<R> : SagaEffect<R>() where R : Any {
   }
 
   /**
-   * See [ISagaOutput.await]. We invoke this [SingleSagaEffect] with [input] then call
+   * See [ISagaOutput.await]. We invoke this [SingleEffect] with [input] then call
    * [ISagaOutput.await].
    * @param input A [SagaInput] instance.
    * @param timeoutMillis Timeout time in milliseconds.

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/PutEffect.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/PutEffect.kt
@@ -13,7 +13,7 @@ import org.swiften.redux.core.IReduxAction
  * [ISagaEffect] whose [ISagaOutput] dispatches some [IReduxAction].
  * @param action The [IReduxAction] to be dispatched.
  */
-class PutEffect(private val action: IReduxAction) : SingleSagaEffect<Any>() {
+class PutEffect(private val action: IReduxAction) : SingleEffect<Any>() {
   override fun invoke(p1: SagaInput): ISagaOutput<Any> {
     return SagaOutput(p1.monitor, Single.create<Any> {
       p1.dispatch(this@PutEffect.action).await()
@@ -22,7 +22,7 @@ class PutEffect(private val action: IReduxAction) : SingleSagaEffect<Any>() {
   }
 
   /**
-   * Since the result type of this [SingleSagaEffect] is [Any], we can have an [await] method that
+   * Since the result type of this [SingleEffect] is [Any], we can have an [await] method that
    * does not require default value.
    * @param input A [SagaInput] instance.
    * @return [Any] value.

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/SagaOutput.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/SagaOutput.kt
@@ -9,8 +9,6 @@ import io.reactivex.Flowable
 import io.reactivex.Scheduler
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.rx2.rxSingle
 import org.swiften.redux.core.DefaultUniqueIDProvider
 import org.swiften.redux.core.IActionDispatcher
 import org.swiften.redux.core.IUniqueIDProvider
@@ -41,19 +39,14 @@ class SagaOutput<T : Any>(
 ) : ISagaOutput<T>, IUniqueIDProvider by DefaultUniqueIDProvider() {
   companion object {
     /**
-     * Create a [ISagaOutput] from [creator] using [rxSingle].
+     * Create a [ISagaOutput] from [creator] using [Flowable.defer].
      * @param T The emission value type.
-     * @param scope A [CoroutineScope] instance.
      * @param monitor See [SagaOutput.monitor].
      * @param creator Suspending function that produces [T].
      * @return An [ISagaOutput] instance.
      */
-    fun <T> from(
-      scope: CoroutineScope,
-      monitor: ISagaMonitor,
-      creator: suspend CoroutineScope.() -> T
-    ): ISagaOutput<T> where T : Any {
-      return SagaOutput(monitor, rxSingle { creator() }.toFlowable())
+    fun <T> from(monitor: ISagaMonitor, creator: () -> T): ISagaOutput<T> where T : Any {
+      return SagaOutput(monitor, Flowable.defer { Flowable.just(creator()) })
     }
 
     /**

--- a/common/common-saga/src/main/kotlin/org/swiften/redux/saga/SelectEffect.kt
+++ b/common/common-saga/src/main/kotlin/org/swiften/redux/saga/SelectEffect.kt
@@ -18,7 +18,7 @@ import io.reactivex.Single
 class SelectEffect<State, R>(
   private val cls: Class<State>,
   private val selector: (State) -> R
-) : SingleSagaEffect<R>() where R : Any {
+) : SingleEffect<R>() where R : Any {
   override fun invoke(p1: SagaInput): ISagaOutput<R> {
     return SagaOutput(p1.monitor, Single.create<R> {
       val lastState = p1.lastState()

--- a/common/common-saga/src/test/java/org/swiften/redux/saga/ReduxSagaTest.java
+++ b/common/common-saga/src/test/java/org/swiften/redux/saga/ReduxSagaTest.java
@@ -24,9 +24,8 @@ public final class ReduxSagaTest {
   public void test_invokingSagaWithJava_shouldWork() throws Exception {
     // Setup
     Object value = from(Flowable.just(1))
-      .transform(flatMap(v -> await((c, input) -> v * 2)))
+      .transform(flatMap(v -> await((input) -> v * 2)))
       .invoke(new SagaInput(
-        EmptyCoroutineContext.INSTANCE,
         a -> EmptyAwaitable.INSTANCE,
         () -> 0,
         new SagaMonitor(),

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/SagaMiddlewareTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/SagaMiddlewareTest.kt
@@ -10,7 +10,6 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import io.reactivex.disposables.Disposables
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.SupervisorJob
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -41,13 +40,12 @@ class SagaMiddlewareTest : BaseMiddlewareTest() {
       on { this.subscribe(any(), any()) } doReturn Disposables.fromAction {}
     } }
 
-    val context = SupervisorJob()
     val monitor = SagaMonitor()
     val effects = outputs.map<ISagaOutput<Any>, ISagaEffect<Any>> { o -> { o } }
     val input = this.mockMiddlewareInput(0)
     outputs.forEachIndexed { i, o -> monitor.addOutputDispatcher(i.toLong(), o.onAction) }
 
-    val middleware = SagaMiddleware.create(context, monitor, Schedulers.computation(), effects)
+    val middleware = SagaMiddleware.create(monitor, Schedulers.computation(), effects)
     val wrappedDispatch = middleware.invoke(input)(this.mockDispatchWrapper()).dispatch
 
     // When
@@ -58,7 +56,6 @@ class SagaMiddlewareTest : BaseMiddlewareTest() {
 
     // Then
     assertEquals(dispatched.get(), dispatchers.size * 4)
-    assertTrue(context.isCancelled)
     assertTrue(middleware.composite.isDisposed)
   }
 }

--- a/common/common-saga/src/test/kotlin/org/swiften/redux/saga/SagaMiddlewareTest.kt
+++ b/common/common-saga/src/test/kotlin/org/swiften/redux/saga/SagaMiddlewareTest.kt
@@ -29,7 +29,7 @@ class SagaMiddlewareTest : BaseMiddlewareTest() {
     val dispatched = AtomicInteger()
 
     val dispatchers: List<IActionDispatcher> = (0 until 100).map {
-      fun(_: IReduxAction): IAwaitable<Any> {
+      fun(_: IReduxAction): IAwaitable<*> {
         dispatched.incrementAndGet()
         return EmptyAwaitable
       }

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Container.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Container.kt
@@ -13,7 +13,7 @@ import org.swiften.redux.core.IReduxSubscription
  * @param LState The local state type that the global state must extend from.
  * @param OutProp Property as defined by a view's parent.
  */
-interface IPropLifecycleOwner<LState, OutProp> where LState : Any {
+interface IPropLifecycleOwner<LState, OutProp> {
   /**
    * This is called before [IFullPropInjector.inject] is called.
    * @param sp A [StaticProp] instance.
@@ -33,7 +33,7 @@ interface IPropLifecycleOwner<LState, OutProp> where LState : Any {
  * @param LState The local state type that the global state must extend from.
  * @param OutProp Property as defined by a view's parent.
  */
-class NoopPropLifecycleOwner<LState, OutProp> : IPropLifecycleOwner<LState, OutProp> where LState : Any {
+class NoopPropLifecycleOwner<LState, OutProp> : IPropLifecycleOwner<LState, OutProp> {
   override fun beforePropInjectionStarts(sp: StaticProp<LState, OutProp>) {}
   override fun afterPropInjectionEnds(sp: StaticProp<LState, OutProp>) {}
 }
@@ -43,6 +43,6 @@ class NoopPropLifecycleOwner<LState, OutProp> : IPropLifecycleOwner<LState, OutP
  * @param State See [ReduxProp.state].
  * @param Action See [ReduxProp.action].
  */
-interface IPropContainer<State, Action> where State : Any, Action : Any {
+interface IPropContainer<State, Action> {
   var reduxProp: ReduxProp<State, Action>
 }

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Injector.kt
@@ -24,7 +24,7 @@ import kotlin.concurrent.write
  * Inject state and actions into an [IPropContainer].
  * @param GState The global state type.
  */
-interface IPropInjector<GState> : IStateGetterProvider<GState>, IReduxUnsubscriberProvider where GState : Any {
+interface IPropInjector<GState> : IStateGetterProvider<GState>, IReduxUnsubscriberProvider {
   /**
    * Inject [State] and [Action] into [view].
    *
@@ -46,12 +46,9 @@ interface IPropInjector<GState> : IStateGetterProvider<GState>, IReduxUnsubscrib
     view: View,
     mapper: IPropMapper<LState, OutProp, State, Action>
   ): IReduxSubscription where
-    LState : Any,
     View : IUniqueIDProvider,
     View : IPropContainer<State, Action>,
-    View : IPropLifecycleOwner<LState, OutProp>,
-    State : Any,
-    Action : Any
+    View : IPropLifecycleOwner<LState, OutProp>
 }
 
 /**
@@ -62,7 +59,7 @@ interface IPropInjector<GState> : IStateGetterProvider<GState>, IReduxUnsubscrib
 interface IFullPropInjector<GState> :
   IPropInjector<GState>,
   IDispatcherProvider,
-  IDeinitializerProvider where GState : Any
+  IDeinitializerProvider
 
 /**
  * A [IFullPropInjector] implementation that handles [inject] in a thread-safe manner. It also
@@ -71,7 +68,7 @@ interface IFullPropInjector<GState> :
  * @param GState The global state type.
  * @param store An [IReduxStore] instance.
  */
-open class PropInjector<GState : Any> protected constructor(
+open class PropInjector<GState> protected constructor(
   private val store: IReduxStore<GState>
 ) : IFullPropInjector<GState>,
   IDispatcherProvider by store,
@@ -90,12 +87,10 @@ open class PropInjector<GState : Any> protected constructor(
     view: View,
     mapper: IPropMapper<LState, OutProp, State, Action>
   ): IReduxSubscription where
-    LState : Any,
     View : IUniqueIDProvider,
     View : IPropContainer<State, Action>,
-    View : IPropLifecycleOwner<LState, OutProp>,
-    State : Any,
-    Action : Any {
+    View : IPropLifecycleOwner<LState, OutProp>
+  {
     val subscriberId = view.uniqueID
 
     /** If [view] has received an injection before, unsubscribe from that. */

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Mapper.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Mapper.kt
@@ -14,7 +14,7 @@ import org.swiften.redux.core.IActionDispatcher
  * @param OutProp Property as defined by a view's parent.
  * @param State The container state.
  */
-interface IStateMapper<in LState, in OutProp, out State> where LState : Any, State : Any {
+interface IStateMapper<in LState, in OutProp, out State> {
   /**
    * Map [LState] to [State] using [OutProp]
    * @param state The latest [LState] instance.
@@ -34,7 +34,7 @@ interface IStateMapper<in LState, in OutProp, out State> where LState : Any, Sta
  * @param OutProp Property as defined by a view's parent.
  * @param Action See [ReduxProp.action].
  */
-interface IActionMapper<in OutProp, out Action> where Action : Any {
+interface IActionMapper<in OutProp, out Action> {
   /**
    * Map [IActionDispatcher] to [Action] using [OutProp].
    * @param dispatch An [IActionDispatcher] instance.
@@ -59,4 +59,3 @@ interface IActionMapper<in OutProp, out Action> where Action : Any {
 interface IPropMapper<in LState, in OutProp, out State, out Action> :
   IStateMapper<LState, OutProp, State>,
   IActionMapper<OutProp, Action>
-  where LState : Any, State : Any, Action : Any

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/ObservableProp.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/ObservableProp.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.KProperty
  * @param T The property type to be observed.
  * @param notifier Broadcast the latest [T] instance.
  */
-open class LateinitObservableProp<T>(private val notifier: (T?, T) -> Unit) : ReadWriteProperty<Any?, T> where T : Any {
+open class LateinitObservableProp<T : Any>(private val notifier: (T?, T) -> Unit) : ReadWriteProperty<Any?, T> {
   private lateinit var value: T
   private val lock by lazy { ReentrantReadWriteLock() }
 
@@ -37,6 +37,6 @@ open class LateinitObservableProp<T>(private val notifier: (T?, T) -> Unit) : Re
  * @param Action See [ReduxProp.action].
  * @param notifier See [LateinitObservableProp.notifier].
  */
-class ObservableReduxProp<State : Any, Action : Any>(
+class ObservableReduxProp<State, Action>(
   notifier: (IVariableProp<State, Action>?, IVariableProp<State, Action>) -> Unit
 ) : ReadWriteProperty<Any?, ReduxProp<State, Action>> by LateinitObservableProp(notifier)

--- a/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
+++ b/common/common-ui/src/main/kotlin/org/swiften/redux/ui/Props.kt
@@ -11,7 +11,7 @@ package org.swiften.redux.ui
  * @param State State type that contains view information.
  * @param Action Action type that handles view interactions.
  */
-interface IVariableProp<out State, out Action> where State : Any, Action : Any {
+interface IVariableProp<out State, out Action> {
   val firstTime: Boolean
   val state: State
   val action: Action
@@ -25,7 +25,7 @@ interface IVariableProp<out State, out Action> where State : Any, Action : Any {
 data class StaticProp<LState, OutProp>(
   val injector: IPropInjector<LState>,
   val outProp: OutProp
-) where LState : Any
+)
 
 /**
  * Container for [state] and [action].
@@ -39,4 +39,4 @@ data class ReduxProp<State, Action>(
   override val firstTime: Boolean,
   override val state: State,
   override val action: Action
-) : IVariableProp<State, Action> where State : Any, Action : Any
+) : IVariableProp<State, Action>

--- a/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
+++ b/common/common-ui/src/test/kotlin/org/swiften/redux/ui/PropInjectorTest.kt
@@ -29,7 +29,7 @@ open class PropInjectorTest {
     data class SetQuery(val query: String) : Action()
   }
 
-  class TestInjector<GState>(store: IReduxStore<GState>) : PropInjector<GState>(store) where GState : Any
+  class TestInjector<GState>(store: IReduxStore<GState>) : PropInjector<GState>(store)
 
   class StoreWrapper(private val store: IReduxStore<S>) : IReduxStore<S> by store {
     val unsubscribeCount = AtomicInteger()

--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -109,7 +109,6 @@ configure(subprojects - project(":sample-android:sample-no-android")) {
     val implementation by configurations
     implementation("androidx.multidex:multidex:${project.extra["multidex"]}")
     implementation("io.reactivex.rxjava2:rxjava:${project.extra["rxJava"]}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${project.extra["kotlinCoroutines"]}")
   }
 }
 
@@ -165,7 +164,6 @@ configure(subprojects - project(":sample-android:sample-sunflower")) {
     implementation(fileTree("libs").include("*.jar"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${project.extra["kotlin"]}")
     implementation("androidx.constraintlayout:constraintlayout:${project.ext["constraintlayout"]}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${project.ext["kotlinCoroutines"]}")
     implementation("com.beust:klaxon:5.0.1")
     testImplementation("junit:junit:${project.ext["junit"]}")
     debugImplementation("com.squareup.leakcanary:leakcanary-android:${project.ext["leakCanary"]}")
@@ -259,8 +257,9 @@ configure(arrayListOf(
     implementation("com.google.android.material:material:${project.extra["materialVersion"]}")
     implementation("com.google.code.gson:gson:${project.extra["gsonVersion"]}")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${project.extra["kotlin"]}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${project.extra["kotlinCoroutines"]}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutines"]}")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${project.extra["kotlinCoroutines"]}")
+
 
     // Testing dependencies
     androidTestImplementation("androidx.arch.core:core-testing:${project.extra["androidxArchCoreTest"]}")

--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -112,15 +112,6 @@ configure(subprojects - project(":sample-android:sample-no-android")) {
   }
 }
 
-configure(arrayListOf(
-  project(":sample-android:sample-dagger")
-)) {
-  configure<KtlintExtension> {
-    /** https://github.com/pinterest/ktlint */
-    disabledRules.set(setOf("filename"))
-  }
-}
-
 data class ApiVersionImpl(private val apiLevel: Int) : ApiVersion {
   override fun getApiLevel(): Int {
     return this.apiLevel
@@ -173,9 +164,23 @@ configure(subprojects - project(":sample-android:sample-sunflower")) {
 }
 
 configure(arrayListOf(
+  project(":sample-android:sample-simple")
+)) {
+  dependencies {
+    val testImplementation by configurations
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinCoroutines"]}")
+  }
+}
+
+configure(arrayListOf(
   project(":sample-android:sample-dagger")
 )) {
   apply(plugin = "kotlin-kapt")
+
+  configure<KtlintExtension> {
+    /** https://github.com/pinterest/ktlint */
+    disabledRules.set(setOf("filename"))
+  }
 
   dependencies {
     val implementation by configurations

--- a/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingRepository.kt
+++ b/sample-android/sample-sunflower/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingRepository.kt
@@ -23,12 +23,9 @@ import kotlinx.coroutines.withContext
 class GardenPlantingRepository private constructor(
   private val gardenPlantingDao: GardenPlantingDao
 ) {
-
-  suspend fun createGardenPlanting(plantId: String) {
-    withContext(IO) {
-      val gardenPlanting = GardenPlanting(plantId)
-      gardenPlantingDao.insertGardenPlanting(gardenPlanting)
-    }
+  fun createGardenPlanting(plantId: String) {
+    val gardenPlanting = GardenPlanting(plantId)
+    gardenPlantingDao.insertGardenPlanting(gardenPlanting)
   }
 
   suspend fun removeGardenPlanting(gardenPlanting: GardenPlanting) {


### PR DESCRIPTION
The use case for Kotlin Coroutines in common-saga was relatively small, but it in turn resulted in a lot of bloat. Therefore, it's better to extract coroutine integration into a separate package if necessary. For now, common-saga will only rely on rxjava2.

Also removed a lot of unnecessary `: Any` constraints.