### PR TITLE
chore(build): simplify gradle configuration for sample projects

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -150,14 +150,6 @@ project(":common:common-all") {
     project.evaluationDependsOn(dependencyName)
   }
 
-  dependencies {
-    val implementation by configurations
-
-    allDependencies.forEach { dependency ->
-      implementation(dependency)
-    }
-  }
-
   tasks {
     val replaceNormalJarWithFatJar by registering {
       doLast {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -176,18 +176,12 @@ project(":common:common-all") {
 
       dependsOn(project.tasks["clean"])
     }
-  }
 
-  afterEvaluate {
     /**
      * Include all dependencies' jar contents into the final jar archive. Use this task instead of
      * the ones defined above (which are mainly for experimenting).
-     *
-     * We do not put this logic in the default jar task because it might break the sample projects
-     * if said projects depend on this using "implementation project" (instead of directly on the
-     * output jar). For example, an error that could arise is "Duplicate classes" in classes.dex.
      */
-    tasks.register("packageFatJar", Jar::class) {
+    "jar"(Jar::class) {
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
       allDependencies.forEach { dependency ->
@@ -199,20 +193,10 @@ project(":common:common-all") {
       }
     }
 
-    tasks {
-      val jar by getting
-      val packageFatJar by getting
+    val jar by getting
 
-      allDependencies.forEach { dependency ->
-        packageFatJar.dependsOn(dependency.tasks["jar"])
-      }
-
-      /** Make sure packageFatJar runs after jar to produce the correct jar */
-      packageFatJar.mustRunAfter(jar)
-
-      "assemble" {
-        dependsOn(packageFatJar)
-      }
+    allDependencies.forEach { dependency ->
+      jar.dependsOn(dependency.tasks["jar"])
     }
   }
 }

--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -73,7 +73,7 @@ fun Project.dependOnLocalLib(
           name = dependencyName,
           outputDir = "${dependency.buildDir.absolutePath}/libs",
           outputGlob = "*.jar",
-          outputTask = "packageFatJar",
+          outputTask = "jar",
         )
       }
     }.forEach { dependencyDetails ->

--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -4,6 +4,8 @@ import com.android.builder.model.ApiVersion
 import org.jetbrains.kotlin.gradle.internal.AndroidExtensionsExtension
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
+println(System.getenv())
+
 buildscript {
   val rootAbsolutePath = projectDir.parent
   apply(from = "$rootAbsolutePath/constants.gradle")
@@ -32,6 +34,10 @@ subprojects {
   apply(plugin = "org.jlleitschuh.gradle.ktlint")
   apply(from = "$rootAbsolutePath/android/constants.gradle")
   apply(from = "$rootAbsolutePath/sample-android/constants.gradle")
+
+  tasks.whenTaskAdded(delegateClosureOf<Task> {
+    onlyIf { false }
+  })
 }
 
 fun Project.dependOnLocalLib(


### PR DESCRIPTION
Simplify the configurations for sample projects by skipping all tasks in Jitpack builds. Empirically, this has led to a big drop in build times and more consistent successful builds.

There are also some changes to the dependency structure of :common-all (ie removing direct dependency on other :common-* projects) in order to solve duplicate class errors in dependents. Let's see if this introduces any problem in the future.